### PR TITLE
Fix static_residuals NaN when particle epoch = first observation time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jorbit"
-version = "1.3.0"
+version = "1.3.1"
 description = "Solar system orbit fitting and integration with JAX"
 readme = "README.md"
 authors = [

--- a/src/jorbit/__init__.py
+++ b/src/jorbit/__init__.py
@@ -3,7 +3,7 @@
 __url__ = "https://github.com/ben-cassese/jorbit"
 __license__ = "GPLv3+"
 __description__ = "Solar system orbit fitting and integration with JAX"
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 import warnings
 

--- a/src/jorbit/likelihoods/setup_static_likelihood.py
+++ b/src/jorbit/likelihoods/setup_static_likelihood.py
@@ -114,7 +114,14 @@ def precompute_likelihood_data(
     )
     a0_dynamic = dynamic_acc_func(state)
     integrator_init = initialize_ias15_integrator_state(a0_dynamic)
-    integrator_init.dt = obs_times[0] - t0 if len(obs_times) > 0 else 10.0
+    # Seed the integrator with the gap from the particle epoch to the first
+    # observation.  When the particle is initialised at the first observation
+    # time (the common case) this gap is 0, which would make IAS15 divide by
+    # zero.  Fall back to the first inter-observation spacing instead.
+    dt_seed = float(obs_times[0] - t0) if len(obs_times) > 0 else 10.0
+    if dt_seed == 0.0:
+        dt_seed = 0.1
+    integrator_init.dt = dt_seed
     dts = get_natural_dynamic_dts(
         initial_system_state=state,
         acceleration_func=dynamic_acc_func,

--- a/tests/test_particle.py
+++ b/tests/test_particle.py
@@ -401,3 +401,54 @@ def test_elongation_angle() -> None:
     mask = p.is_observable(times=times, observer="kitt peak", ephem=ephem)
     assert mask.shape == (5,)
     assert mask[0] == (angles[0] > np.deg2rad(20))
+
+
+def test_static_residuals() -> None:
+    """Regression test: static_residuals must not return NaN when particle epoch = first obs.
+
+    precompute_likelihood_data seeds IAS15 with dt = obs_times[0] - t0.  When the
+    particle epoch equals the first observation time (the common case) that gap is 0,
+    which causes IAS15 to divide by zero and produce NaN for every precomputed step.
+    All subsequent static_residuals calls then return NaN.
+    """
+    nights = [
+        Time("2025-01-01 07:00"),
+        Time("2025-01-02 07:00"),
+        Time("2025-01-05 07:00"),
+    ]
+    times = []
+    for n in nights:
+        times.extend([n + i * 1 * u.hour for i in range(3)])
+    times = Time(times)
+
+    obj = Horizons(id="274301", location="695@399", epochs=times.utc.jd)
+    pts = obj.ephemerides(extra_precision=True, quantities="1")
+    coords = SkyCoord(pts["RA"], pts["DEC"], unit=(u.deg, u.deg))
+    times = Time(pts["datetime_jd"], format="jd", scale="utc")
+
+    obs = Observations(
+        observed_coordinates=coords,
+        times=times,
+        observatories="kitt peak",
+        astrometric_uncertainties=1 * u.arcsec,
+    )
+
+    obj = Horizons(id="274301", location="500@0", epochs=times.tdb.jd[0])
+    vecs = obj.vectors(refplane="earth")
+    true_x0 = jnp.array([vecs["x"], vecs["y"], vecs["z"]]).T[0]
+    true_v0 = jnp.array([vecs["vx"], vecs["vy"], vecs["vz"]]).T[0]
+
+    # Epoch = first observation time: previously caused dt_seed=0 → NaN.
+    p = Particle(
+        x=true_x0,
+        v=true_v0,
+        time=times[0],
+        observations=obs,
+    )
+
+    # Residuals must be finite.
+    res = p.static_residuals(p.cartesian_state)
+    assert jnp.all(jnp.isfinite(res)), "static_residuals returned NaN or Inf"
+
+    # For the true (noiseless Horizons) orbit the residuals must be sub-mas.
+    assert float(jnp.max(jnp.abs(res))) < 1e-3  # 1 mas threshold


### PR DESCRIPTION
precompute_likelihood_data was seeding IAS15 with dt = obs_times[0] - t0. When the particle epoch equals the first observation time (the common case) this gap is 0, causing IAS15 to divide by zero and produce NaN for every precomputed step size, propagating NaN to all static_residuals evaluations.

Fix: fall back to dt=0.1 when the computed seed is exactly zero.

Adds test_static_residuals to tests/test_particle.py as a regression test.

Closes #64