### PR TITLE
new tests/fixes

### DIFF
--- a/docs/user_guide/changelog.rst
+++ b/docs/user_guide/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 +++++++++
 
+**1.4.0 (05/2026)**
+
+- Added `uncertainty=True` as an option to `Particle.ephemeris` that returns the propagated on-sky covariance in addition to the propagated state. This is implemented by computing the Jacobian of the dynamics using forward autodiff, then linear error propagation using the initial covariance on the `CartesianState` or `KeplerianState`.
+- Several misc bug fixes found by Claude's recent code audit, including some precision loss issues when combining `Observation` objects and array shape mismatches.
+
 **1.3.0 (05/2026)**
 
 - Instead of taking an IAS15 step to the exact observation times, the `static_step` now takes natural IAS15 adaptive steps and evaluates the relevant polynomials based on the b coefficients to compute positions/velocities at arbitrary times within a step. This cuts down the number of IAS15 steps substatially when observations are spaced within a typical maximum-allowable IAS15 step, or ~30 days. This involves lots of changes to the internal `ias_15_evolve` function and the creation of some new internal helpers like `ias15_evolve_with_dense_output`, `ias15_evolve_forced_landing` and `interpolate_from_dense_output`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jorbit"
-version = "1.3.1"
+version = "1.4.0"
 description = "Solar system orbit fitting and integration with JAX"
 readme = "README.md"
 authors = [

--- a/src/jorbit/__init__.py
+++ b/src/jorbit/__init__.py
@@ -3,7 +3,7 @@
 __url__ = "https://github.com/ben-cassese/jorbit"
 __license__ = "GPLv3+"
 __description__ = "Solar system orbit fitting and integration with JAX"
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 
 import warnings
 

--- a/src/jorbit/mpchecker/parse_jorbit_ephem.py
+++ b/src/jorbit/mpchecker/parse_jorbit_ephem.py
@@ -418,7 +418,7 @@ def extra_precision_calcs(
         massive_velocities=jnp.empty((0, 3)),
         log_gms=jnp.empty((0,)),
         acceleration_func_kwargs={},
-        time=Time("2020-01-01").tdb.jd,
+        time=Time("2020-01-01"),
         fixed_perturber_positions=jnp.empty((0, 3)),
         fixed_perturber_velocities=jnp.empty((0, 3)),
         fixed_perturber_log_gms=jnp.empty((0,)),

--- a/src/jorbit/observation.py
+++ b/src/jorbit/observation.py
@@ -129,12 +129,31 @@ class Observations:
         if isinstance(self._observatories, jnp.ndarray):
             observatories = self._slice_observation_axis(self._observatories, index)
 
+        # Preserve the high-precision astropy Time if available. Passing it as
+        # `times` lets the constructor set _times_astropy correctly, so that
+        # downstream code (_observations_times_as_offsets, precompute_likelihood_data)
+        # can still use the full jd1+jd2 precision path.
+        # Integer indexing on an astropy Time array returns a scalar Time, which
+        # doesn't have len() and breaks _input_checks. Wrap it to stay 1-D.
+        if self._times_astropy is not None:
+            t_sliced = self._times_astropy[index]
+            if t_sliced.isscalar:
+                t_sliced = Time([t_sliced.jd], format="jd", scale=t_sliced.scale)
+            times = t_sliced
+
+        # _astrometric_uncertainties is stored internally in arcsec (1-D) or as
+        # dimensionless arcsec² covariance matrices (N, 2, 2). The constructor
+        # distinguishes these by ndim, so we pass the raw JAX array directly:
+        # attaching `* u.arcsec` is wrong for the covariance-matrix path (the
+        # unit would be arcsec, not arcsec²) and unnecessary for the 1-D path
+        # (the values are already in arcsec). mpc_file is cleared: the slice
+        # is no longer the full file.
         return Observations(
             observed_coordinates=SkyCoord(ra=ra, dec=dec, unit=u.rad),
             times=times,
             observatories=observatories,
-            astrometric_uncertainties=astrometric_uncertainties * u.arcsec,
-            mpc_file=self._mpc_file,
+            astrometric_uncertainties=astrometric_uncertainties,
+            mpc_file=None,
         )
 
     @staticmethod

--- a/src/jorbit/particle.py
+++ b/src/jorbit/particle.py
@@ -191,6 +191,12 @@ class Particle:
         self._step_scheduler = self._resolve_step_scheduler(step_scheduler)
 
         self.gravity = gravity
+        # Preserve the original gravity spec (string or user-supplied Partial) so
+        # max_likelihood can pass it to the result Particle rather than self.gravity.
+        # self.gravity is overwritten by _setup_acceleration_func with a Partial that
+        # already has t_ref_jd baked in; passing *that* Partial to a new Particle would
+        # re-wrap it a second time and double-count the offset (see BUG_FIXES_MAY2026).
+        self._gravity_str = gravity
 
         state = deepcopy(state) if state is not None else None
 
@@ -345,6 +351,13 @@ class Particle:
         if state is not None:
             assert x is None and v is None, "Cannot provide both state and x, v"
 
+            # to_keplerian() and to_cartesian() are documented not to propagate `cov`
+            # because the covariance is parameterisation-specific. Save and re-attach
+            # it to the same-type output state so callers who set cov on the input
+            # state can retrieve it on particle.cartesian_state / particle.keplerian_state.
+            _input_is_keplerian = isinstance(state, KeplerianState)
+            _input_cov = state.cov
+
             state = state.to_cartesian()
             if state.x.ndim != 2:
                 state.x = state.x[None, :]
@@ -353,6 +366,11 @@ class Particle:
             state.time_reference = t_ref_jd
             keplerian_state = state.to_keplerian()
             cartesian_state = state.to_cartesian()
+
+            if _input_is_keplerian:
+                keplerian_state.cov = _input_cov
+            else:
+                cartesian_state.cov = _input_cov
 
             x = state.x.flatten()
             v = state.v.flatten()
@@ -395,10 +413,20 @@ class Particle:
 
     def _setup_acceleration_func(self, gravity: str) -> Callable:
         if isinstance(gravity, jax.tree_util.Partial):
-            # User-supplied acc funcs pre-date the rebase and expect state.time
-            # to be an absolute JD. Internally we now pass state.time as an
-            # offset from t_ref_jd, so we wrap the user's function to shift
-            # state.time back to absolute JD before calling it.
+            # The wrapper converts from the Particle's internal offset frame
+            # (state.time = days since self._t_ref_jd) to absolute JD before
+            # calling the user's function, which must expect absolute JD.
+            #
+            # CONTRACT: the custom function must be built with t_ref_jd=0 (or
+            # equivalently, must treat state.time as an absolute Julian Date).
+            # Do NOT pass a function returned by jorbit's factory functions
+            # (create_default_ephemeris_acceleration_func, etc.) that was
+            # built with a non-zero t_ref_jd — that would double-count the
+            # offset and silently query the ephemeris at the wrong time.
+            # The safe pattern is to build the function fresh with t_ref_jd=0:
+            #   acc_func = create_default_ephemeris_acceleration_func(
+            #       eph.processor, t_ref_jd=0.0
+            #   )
             user_func = gravity
             t_ref_jd = self._t_ref_jd
 
@@ -462,6 +490,13 @@ class Particle:
             )
             acc_func = create_default_ephemeris_acceleration_func(
                 eph.processor, t_ref_jd=self._t_ref_jd
+            )
+        else:
+            raise ValueError(
+                f"Unrecognized gravity '{gravity}'. Valid options are: 'newtonian planets', "
+                "'newtonian solar system', 'gr planets', 'gr solar system', "
+                "'default solar system', 'keplerian'. For a custom acceleration function, "
+                "pass a jax.tree_util.Partial."
             )
 
         return acc_func
@@ -533,6 +568,11 @@ class Particle:
                     stacklevel=2,
                 )
         else:
+            # Pass the Particle's reference epoch (not the observation time)
+            # so that the returned state's x, v represent the object at
+            # self._t_ref_jd — the same epoch the optimizer will use as its
+            # starting point. Using obs.times[0] instead would yield x, v at
+            # a different epoch that the optimizer would then misinterpret.
             fit_seed = simple_circular(
                 self._observations.ra[0],
                 self._observations.dec[0],
@@ -1165,7 +1205,8 @@ class Particle:
                 state=None,
                 observations=self._observations,
                 name=self._name,
-                gravity=self.gravity,
+                gravity=self._gravity_str,
+                de_ephemeris_version=self._de_ephemeris_version,
                 integrator=self._integrator_method,
                 earliest_time=self._earliest_time,
                 latest_time=self._latest_time,

--- a/src/jorbit/system.py
+++ b/src/jorbit/system.py
@@ -110,8 +110,8 @@ class System:
             assert particles is not None
             t_ref_jds = jnp.array([p._t_ref_jd for p in particles])
             assert jnp.allclose(
-                t_ref_jds, t_ref_jds[0]
-            ), "All particles must have the same reference time"
+                t_ref_jds, t_ref_jds[0], atol=1e-6, rtol=0
+            ), "All particles must have the same reference time (tolerance: 1e-6 days ~ 0.1 s)"
             self._t_ref_astropy = particles[0]._t_ref_astropy
             self._t_ref_jd = particles[0]._t_ref_jd
 
@@ -132,7 +132,14 @@ class System:
             if isinstance(t_in, Time):
                 t_ref_astropy = t_in.tdb
             else:
-                t_ref_astropy = Time(float(t_in), format="jd", scale="tdb")
+                raise ValueError(
+                    "Cannot determine the absolute epoch from a SystemState whose "
+                    "time field is a numeric offset. SystemState.time is an "
+                    "integration offset (typically 0.0), not an absolute JD. "
+                    "To build a System from an existing particle state, use "
+                    "System(particles=[particle]) or set state.time to an "
+                    "astropy Time object representing the absolute epoch."
+                )
             self._t_ref_astropy = t_ref_astropy
             self._t_ref_jd = jnp.array(float(t_ref_astropy.tdb.jd))
             self._state = state.replace(time=jnp.array(0.0))
@@ -198,10 +205,12 @@ class System:
     def _setup_acceleration_func(self, gravity: str | Callable) -> Callable:
 
         if isinstance(gravity, jax.tree_util.Partial):
-            # User-supplied acc funcs pre-date the rebase and expect state.time
-            # to be an absolute JD. Internally we now pass state.time as an
-            # offset from t_ref_jd, so we wrap the user's function to shift
-            # state.time back to absolute JD before calling it.
+            # See Particle._setup_acceleration_func for the full rationale.
+            # CONTRACT: the custom function must be built with t_ref_jd=0 and
+            # must treat state.time as an absolute Julian Date. Do NOT pass a
+            # jorbit factory function built with a non-zero t_ref_jd — that
+            # would double-count the offset and silently query the ephemeris
+            # at the wrong absolute time.
             user_func = gravity
             t_ref_jd = self._t_ref_jd
 
@@ -264,6 +273,13 @@ class System:
 
         elif gravity == "generic gr":
             acc_func = jax.tree_util.Partial(ppn_gravity)
+        else:
+            raise ValueError(
+                f"Unrecognized gravity '{gravity}'. Valid options are: 'newtonian planets', "
+                "'newtonian solar system', 'gr planets', 'gr solar system', "
+                "'default solar system', 'generic newtonian', 'generic gr', 'keplerian'. "
+                "For a custom acceleration function, pass a jax.tree_util.Partial."
+            )
 
         return acc_func
 

--- a/src/jorbit/utils/states.py
+++ b/src/jorbit/utils/states.py
@@ -354,13 +354,16 @@ def heliocentric_to_barycentric(
             acceleration_func_kwargs=acceleration_func_kwargs,
         )
     elif "a_helio" in heliocentric_dict:
+        # Use .ravel() to handle both scalar floats (from manual user input) and
+        # 1-D arrays (from barycentric_to_heliocentric). jnp.array([array]) would
+        # produce a (1, N) shape for array inputs; .ravel() always gives (N,).
         helio_x, helio_v = elements_to_cartesian(
-            jnp.array([heliocentric_dict["a_helio"]]),
-            jnp.array([heliocentric_dict["ecc_helio"]]),
-            jnp.array([heliocentric_dict["nu_helio"]]),
-            jnp.array([heliocentric_dict["inc_helio"]]),
-            jnp.array([heliocentric_dict["Omega_helio"]]),
-            jnp.array([heliocentric_dict["omega_helio"]]),
+            jnp.asarray(heliocentric_dict["a_helio"]).ravel(),
+            jnp.asarray(heliocentric_dict["ecc_helio"]).ravel(),
+            jnp.asarray(heliocentric_dict["nu_helio"]).ravel(),
+            jnp.asarray(heliocentric_dict["inc_helio"]).ravel(),
+            jnp.asarray(heliocentric_dict["Omega_helio"]).ravel(),
+            jnp.asarray(heliocentric_dict["omega_helio"]).ravel(),
             SUN_GM,
         )
         cart_x = horizons_ecliptic_to_icrs(helio_x) + sun_state["x"].value

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,325 @@
+"""End-to-end tests probing time handling and object combination edge cases.
+
+These tests target the specific weaknesses identified in the May 2026 bug hunt:
+precision preservation through __getitem__ / __add__, System epoch extraction,
+heliocentric coordinate roundtrips, pre-built covariance matrices, and
+consistency between the static and dynamic residual pipelines.
+"""
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import astropy.units as u
+import jax.numpy as jnp
+import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.time import Time
+
+from jorbit import Observations, Particle
+from jorbit.data.constants import SPEED_OF_LIGHT
+from jorbit.system import System
+from jorbit.utils.states import (
+    CartesianState,
+    barycentric_to_heliocentric,
+    heliocentric_to_barycentric,
+)
+
+# ---------------------------------------------------------------------------
+# Shared synthetic data (no network calls; no Horizons)
+# ---------------------------------------------------------------------------
+
+_X0 = jnp.array([-2.003779703686627, 1.780533558134481, 0.5203350526739642])
+_V0 = jnp.array([-0.006668390915419885, -0.006621147093559814, -0.002036640485149475])
+_T0 = Time("2025-01-01")
+
+
+def _make_obs_with_astropy_times(n_obs: int = 5) -> Observations:
+    """Minimal Observations object with genuine astropy Time precision.
+
+    Uses pre-computed observer positions so no Horizons query is needed.
+    """
+    times = _T0 + np.arange(n_obs) * u.day
+    coords = SkyCoord(
+        ra=np.linspace(0.10, 0.10 + 0.01 * (n_obs - 1), n_obs) * u.rad,
+        dec=np.zeros(n_obs) * u.rad,
+    )
+    # Fake observer positions (we are only testing structure, not astrometry)
+    observer_positions = jnp.zeros((n_obs, 3))
+    return Observations(
+        observed_coordinates=coords,
+        times=times,
+        observatories=observer_positions,
+        astrometric_uncertainties=1.0 * u.arcsec,
+    )
+
+
+# ===========================================================================
+# 1a.  Observations.__getitem__ should preserve times_astropy
+# ===========================================================================
+
+
+def test_observations_getitem_integer_preserves_times_astropy() -> None:
+    """Integer-indexing a high-precision Observations must keep times_astropy."""
+    obs = _make_obs_with_astropy_times(5)
+    assert obs.times_astropy is not None, "baseline: times_astropy must be set"
+
+    sliced = obs[2]
+    assert sliced.times_astropy is not None, (
+        "__getitem__(int) dropped times_astropy; downstream static_residuals "
+        "will silently fall back to float arithmetic"
+    )
+
+
+def test_observations_getitem_slice_preserves_times_astropy() -> None:
+    """Slice-indexing a high-precision Observations must keep times_astropy."""
+    obs = _make_obs_with_astropy_times(5)
+
+    sliced = obs[1:3]
+    assert sliced.times_astropy is not None, "__getitem__(slice) dropped times_astropy"
+    assert len(sliced.times_astropy) == 2
+
+
+def test_observations_sliced_then_added_preserves_times_astropy() -> None:
+    """Slicing then combining (the fit-seed pattern) must keep times_astropy."""
+    obs = _make_obs_with_astropy_times(5)
+
+    combined = obs[0] + obs[2] + obs[-1]
+    assert (
+        combined.times_astropy is not None
+    ), "obs[0] + obs[2] + obs[-1] dropped times_astropy"
+    assert len(combined.times_astropy) == 3
+
+
+# ===========================================================================
+# 1c.  System(state=SystemState) with float time must raise, not silently misuse
+# ===========================================================================
+
+
+def test_system_from_systemstate_with_float_time_raises() -> None:
+    """System(state=SystemState) with float time must raise ValueError.
+
+    state.time is a float offset (common case from CartesianState.to_system());
+    this must raise rather than silently set the epoch to JD 0 (~4713 BC).
+    """
+    import pytest
+
+    p = Particle(x=_X0, v=_V0, time=_T0, gravity="newtonian planets")
+    sys_state = p.cartesian_state.to_system()
+    # sys_state.time == 0.0 (an *offset*, not absolute JD)
+
+    with pytest.raises(ValueError, match="absolute epoch"):
+        System(state=sys_state, gravity="newtonian planets")
+
+
+def test_system_from_particles_has_correct_epoch() -> None:
+    """The standard System(particles=[...]) path must preserve the Particle epoch."""
+    p = Particle(x=_X0, v=_V0, time=_T0, gravity="newtonian planets")
+    sys = System(particles=[p], gravity="newtonian planets")
+
+    assert (
+        abs(sys._t_ref_jd - p._t_ref_jd) < 1e-6
+    ), f"System epoch ({sys._t_ref_jd}) doesn't match Particle epoch ({p._t_ref_jd})"
+
+
+def test_system_from_particles_integrates_consistently() -> None:
+    """System([p]) must give the same 1-day position as Particle.integrate()."""
+    p = Particle(x=_X0, v=_V0, time=_T0, gravity="newtonian planets")
+    sys = System(particles=[p], gravity="newtonian planets")
+
+    target = _T0 + 1 * u.day
+    pos_p, _ = p.integrate(target)  # shape (1, 3)
+    pos_s, _ = sys.integrate(target)  # shape (1, 1, 3)
+
+    diff_m = float(jnp.linalg.norm(pos_p[0] - pos_s[0, 0])) * u.au.to(u.m)
+    assert diff_m < 1000.0, f"Position disagreement after 1 day: {diff_m:.0f} m"
+
+
+# ===========================================================================
+# 1d.  heliocentric_to_barycentric / barycentric_to_heliocentric roundtrip
+# ===========================================================================
+
+
+def test_heliocentric_barycentric_cartesian_roundtrip() -> None:
+    """Bary -> helio -> bary must recover the original Cartesian state."""
+    t = Time("2025-06-01")
+    state = CartesianState(
+        x=jnp.array([_X0]),
+        v=jnp.array([_V0]),
+        time_reference=t.tdb.jd,
+        acceleration_func_kwargs={"c2": SPEED_OF_LIGHT**2},
+    )
+
+    helio = barycentric_to_heliocentric(state, t)
+    recovered = heliocentric_to_barycentric(helio, t)
+
+    assert jnp.allclose(
+        recovered.x.flatten(), state.x.flatten(), atol=1e-10
+    ), "Position roundtrip error exceeds 1e-10 AU"
+    assert jnp.allclose(
+        recovered.v.flatten(), state.v.flatten(), atol=1e-12
+    ), "Velocity roundtrip error exceeds 1e-12 AU/day"
+
+
+def test_heliocentric_barycentric_keplerian_roundtrip() -> None:
+    """Bary -> helio (Keplerian form) -> bary must recover the original Cartesian state."""
+    t = Time("2025-06-01")
+    state = CartesianState(
+        x=jnp.array([_X0]),
+        v=jnp.array([_V0]),
+        time_reference=t.tdb.jd,
+        acceleration_func_kwargs={"c2": SPEED_OF_LIGHT**2},
+    )
+    kep = state.to_keplerian()
+
+    helio = barycentric_to_heliocentric(kep, t)
+    recovered = heliocentric_to_barycentric(helio, t)  # returns KeplerianState
+
+    # Compare via Cartesian
+    rec_cart = recovered.to_cartesian()
+    assert jnp.allclose(
+        rec_cart.x.flatten(), state.x.flatten(), atol=1e-9
+    ), "Keplerian roundtrip position error exceeds 1e-9 AU"
+    assert jnp.allclose(
+        rec_cart.v.flatten(), state.v.flatten(), atol=1e-11
+    ), "Keplerian roundtrip velocity error exceeds 1e-11 AU/day"
+
+
+# ===========================================================================
+# 1e.  Observations with pre-built 2x2 covariance matrices
+# ===========================================================================
+
+
+def test_observations_prebuilt_covariance_matrix() -> None:
+    """Passing a (N, 2, 2) array as astrometric_uncertainties should work."""
+    n = 4
+    times = _T0 + np.arange(n) * u.day
+    coords = SkyCoord(
+        ra=np.linspace(0.10, 0.13, n) * u.rad,
+        dec=np.zeros(n) * u.rad,
+    )
+    observer_positions = jnp.zeros((n, 3))
+
+    sigma = 1.0  # arcsec
+    rho = 0.3
+    cov_1 = jnp.array([[sigma**2, rho * sigma**2], [rho * sigma**2, sigma**2]])
+    cov_matrices = jnp.broadcast_to(cov_1, (n, 2, 2))
+
+    obs = Observations(
+        observed_coordinates=coords,
+        times=times,
+        observatories=observer_positions,
+        astrometric_uncertainties=cov_matrices,
+    )
+
+    assert obs.cov_matrices.shape == (n, 2, 2)
+    assert obs.inv_cov_matrices.shape == (n, 2, 2)
+    assert obs.cov_log_dets.shape == (n,)
+
+    for i in range(n):
+        product = obs.inv_cov_matrices[i] @ obs.cov_matrices[i]
+        assert jnp.allclose(product, jnp.eye(2), atol=1e-10), (
+            f"inv_cov @ cov != I at index {i}: max off-diag = "
+            f"{float(jnp.max(jnp.abs(product - jnp.eye(2)))):.2e}"
+        )
+
+
+# ===========================================================================
+# 1f.  Particle initialised from state with non-zero relative_time
+# ===========================================================================
+
+
+def test_particle_from_state_with_nonzero_relative_time() -> None:
+    """Particle from a state with nonzero relative_time must read epoch correctly.
+
+    ``relative_time + time_reference`` is the absolute epoch. Verified by
+    integrating back 30 days and comparing with the original position.
+    """
+    p_orig = Particle(x=_X0, v=_V0, time=_T0, gravity="newtonian planets")
+
+    t_fwd = _T0 + 30 * u.day
+    pos_fwd, vel_fwd = p_orig.integrate(t_fwd)  # shape (1, 3)
+
+    offset_fwd = p_orig._times_to_offsets(t_fwd)  # should be +30.something days
+    state_fwd = CartesianState(
+        x=pos_fwd.reshape(1, 3),
+        v=vel_fwd.reshape(1, 3),
+        relative_time=offset_fwd,
+        time_reference=p_orig._t_ref_jd,
+        acceleration_func_kwargs={"c2": SPEED_OF_LIGHT**2},
+    )
+
+    # Particle should interpret relative_time + time_reference = t_fwd as epoch
+    p_fwd = Particle(state=state_fwd, gravity="newtonian planets")
+
+    expected_jd = t_fwd.tdb.jd
+    assert abs(p_fwd._t_ref_jd - expected_jd) < 1e-6, (
+        f"p_fwd epoch mismatch: got {p_fwd._t_ref_jd:.6f}, "
+        f"expected {expected_jd:.6f}"
+    )
+
+    # Integrating back 30 days should recover the original position
+    pos_back, _ = p_fwd.integrate(_T0)
+    diff_m = float(jnp.linalg.norm(pos_back[0] - p_orig._x)) * u.au.to(u.m)
+    assert (
+        diff_m < 1000.0
+    ), f"Roundtrip position error: {diff_m:.0f} m (expected < 1000 m)"
+
+
+# ===========================================================================
+# 1b + 1g.  Self-consistent synthetic pipeline: static == dynamic residuals
+# ===========================================================================
+
+
+def test_self_consistent_observations_static_residuals_finite() -> None:
+    """Self-consistent observations must yield near-zero finite static residuals.
+
+    A particle whose observations came from its own ephemeris should have
+    residuals < 1 mas with no NaN or Inf values.
+    """
+    p_true = Particle(x=_X0, v=_V0, time=_T0)
+    times = _T0 + np.array([1, 3, 7, 15, 30]) * u.day
+    eph = p_true.ephemeris(times, "kitt peak")
+
+    obs = Observations(
+        observed_coordinates=eph,
+        times=times,
+        observatories="kitt peak",
+        astrometric_uncertainties=1.0 * u.arcsec,
+    )
+
+    p = Particle(x=_X0, v=_V0, time=_T0, observations=obs)
+
+    res = p.static_residuals(p.cartesian_state)
+    assert jnp.all(jnp.isfinite(res)), "static_residuals returned NaN or Inf"
+    assert (
+        float(jnp.max(jnp.abs(res))) < 1e-3
+    ), f"static_residuals not near-zero: max = {float(jnp.max(jnp.abs(res))):.2e} arcsec"
+
+
+def test_static_and_dynamic_residuals_agree() -> None:
+    """Static and dynamic residuals must agree to < 0.1 mas for a self-consistent orbit."""
+    p_true = Particle(x=_X0, v=_V0, time=_T0)
+    times = _T0 + np.array([2, 5, 10, 20, 40]) * u.day
+    eph = p_true.ephemeris(times, "kitt peak")
+
+    obs = Observations(
+        observed_coordinates=eph,
+        times=times,
+        observatories="kitt peak",
+        astrometric_uncertainties=1.0 * u.arcsec,
+    )
+
+    p = Particle(x=_X0, v=_V0, time=_T0, observations=obs)
+
+    static_res = p.static_residuals(p.cartesian_state)
+    dynamic_res = p.residuals(p.cartesian_state)
+
+    assert jnp.all(jnp.isfinite(static_res)), "static_residuals has NaN/Inf"
+    assert jnp.all(jnp.isfinite(dynamic_res)), "dynamic residuals has NaN/Inf"
+
+    diff = jnp.abs(static_res - dynamic_res)
+    max_diff_mas = float(jnp.max(diff)) * 1000.0
+    assert (
+        max_diff_mas < 0.1
+    ), f"static vs dynamic residuals disagree by {max_diff_mas:.3f} mas (limit 0.1 mas)"

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -55,3 +55,39 @@ def test_added_observations_support_fit_seed_indexing_pattern() -> None:
 
     assert len(seed_obs) == 3
     assert seed_obs.observatories.shape == (3, 3)
+
+
+def test_add_preserves_covariance_consistency() -> None:
+    """inv_cov @ cov should equal identity for every observation after __add__."""
+    obs = _make_observations([0, 2]) + _make_observations([1])
+
+    for i in range(len(obs)):
+        product = obs.inv_cov_matrices[i] @ obs.cov_matrices[i]
+        assert jnp.allclose(
+            product, jnp.eye(2), atol=1e-10
+        ), f"inv_cov @ cov != I at index {i}"
+
+
+def test_single_observation_init() -> None:
+    """A single-observation Observations must initialise correctly."""
+    obs = _make_observations([0.0])
+
+    assert len(obs) == 1
+    assert obs.ra.shape == (1,)
+    assert obs.dec.shape == (1,)
+    assert obs.times.shape == (1,)
+    assert obs.observer_positions.shape == (1, 3)
+    assert obs.astrometric_uncertainties.shape == (1,)
+    assert obs.cov_matrices.shape == (1, 2, 2)
+    assert obs.inv_cov_matrices.shape == (1, 2, 2)
+    assert obs.cov_log_dets.shape == (1,)
+
+
+def test_getitem_negative_index() -> None:
+    """Negative integer indexing must return the last observation correctly."""
+    obs = _make_observations([0, 1, 2])
+    last = obs[-1]
+
+    assert len(last) == 1
+    assert jnp.allclose(last.times, obs.times[-1:])
+    assert jnp.allclose(last.ra, obs.ra[-1:])

--- a/uv.lock
+++ b/uv.lock
@@ -1358,7 +1358,7 @@ wheels = [
 
 [[package]]
 name = "jorbit"
-version = "1.3.1"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },


### PR DESCRIPTION
(bug reports authored by Claude)

# Bug hunt and test coverage — May 2026

## Background

A recent regression (`Observations.__add__` dropping `_times_astropy`, causing
`static_residuals` NaN) prompted a broad code review focused on time handling
and object combination. This PR adds targeted end-to-end tests that exposed
several additional bugs, fixes all confirmed issues, and documents two
non-code footguns.

---

## Bugs fixed

### 1. `Observations.__getitem__` dropped `times_astropy` — `observation.py`

Every slice of an `Observations` object (`obs[0]`, `obs[1:3]`, `obs[-1]`)
returned a new object with `times_astropy = None`, because the method passed
the JAX float array rather than the original astropy `Time`. This silently
degraded the static-likelihood pipeline's precision path and reintroduced the
risk of the dt_seed = 0 NaN that the recent `__add__` fix was intended to
prevent. The fix slices `self._times_astropy` directly and wraps scalar results
(from integer indexing) back into a length-1 array.

### 2. `System(state=SystemState)` set epoch to JD 0 (~4713 BC) — `system.py`

Passing a `SystemState` obtained from `CartesianState.to_system()` to
`System.__init__` caused the System's reference time to be set to Julian Day 0.
`SystemState.time` is an integration *offset* (always 0.0 for standard states),
but the constructor was treating it as an absolute Julian Date. Any subsequent
integration would query the ephemeris around 4713 BC and produce garbage
silently. The fix raises a `ValueError` with a clear message when a numeric
`state.time` is received, directing users to the correct `System(particles=[...])`
pattern.

### 3. `heliocentric_to_barycentric` shape crash for Keplerian roundtrip — `utils/states.py`

Calling `heliocentric_to_barycentric` on a dict produced by
`barycentric_to_heliocentric(keplerian_state, t)` raised a matmul shape error.
The Keplerian path of `barycentric_to_heliocentric` returns orbital elements as
shape-`(1,)` JAX arrays. Wrapping them with `jnp.array([...])` in
`heliocentric_to_barycentric` produced shape `(1, 1)`, which
`elements_to_cartesian` cannot handle. The fix uses `jnp.asarray(...).ravel()`,
which gives `(1,)` for both scalar floats and `(1,)` arrays.

### 4. `__getitem__` applied `* u.arcsec` to covariance matrices — `observation.py`

When an `Observations` object was constructed with pre-built `(N, 2, 2)`
covariance matrices (in arcsec²) and then sliced, `__getitem__` multiplied the
matrices by `u.arcsec`, producing an intermediate quantity with semantically
wrong units (arcsec, not arcsec²). It was numerically harmless only because the
constructor strips units via `.to(u.arcsec).value` (a no-op for same-unit
conversion). The fix passes the raw JAX array directly — the internally stored
values are already in the correct units for both the 1-D (arcsec) and 2-D
covariance (arcsec²) cases. As a secondary fix in the same method, `mpc_file`
is now always `None` for sliced observations, since a slice is no longer the
full file.

### 5. `Particle.max_likelihood` double-wrapped the gravity function in the returned Particle — `particle.py`

`max_likelihood` constructed the result `Particle` with `gravity=self.gravity`, but
`self.gravity` is already a `jax.tree_util.Partial` built by `_setup_acceleration_func`
with a baked-in `t_ref_jd` offset. When a `Partial` is passed to a new `Particle`,
`_setup_acceleration_func` wraps it *again* with a second `t_ref_jd` addition. The
underlying ephemeris query then receives `offset + 2 * t_ref_jd` instead of
`offset + t_ref_jd`, querying the ephemeris thousands of years in the future and
returning garbage accelerations. Every integration or residual call on the returned
`Particle` silently produced wrong results. The fix stores the original gravity
spec (`self._gravity_str`) at construction time and passes it (not `self.gravity`) to
the result `Particle`. `de_ephemeris_version` (previously omitted entirely from the
`max_likelihood` return) is now forwarded as well.

### 6. `System.__init__` epoch-equality check used `jnp.allclose` with loose default tolerances — `system.py`

```python
assert jnp.allclose(t_ref_jds, t_ref_jds[0])
```

`jnp.allclose` defaults to `rtol=1e-5`. For Julian Dates around 2461000 (year 2025),
`rtol * JD ≈ 24.6 days`, so two particles with reference epochs up to 24 days apart
silently passed the check. The `System` then combined their positions (which represent
different epochs) into a single `SystemState(time=0.0)`, making the initial
configuration temporally inconsistent and any subsequent integration wrong. The fix
uses `atol=1e-6, rtol=0` (tolerance ≈ 0.1 seconds).

### 7. `CartesianState.to_keplerian()` and `KeplerianState.to_cartesian()` silently dropped `cov` — `particle.py`

Both cross-type coordinate conversions are documented to *not* propagate `cov` (the
covariance is parameterisation-specific and would need a Jacobian transform to remain
correct). However, `Particle._setup_state` converts through both directions
internally, meaning a user who set `cov` on their input `KeplerianState` found it
silently zeroed out on `particle.keplerian_state`. Any call to
`particle.ephemeris(uncertainty=True)` then raised a confusing `ValueError` about
the missing covariance. The fix saves the original `cov` before the cross-type
conversion in `_setup_state` and re-attaches it to the same-parameterisation output
state (`keplerian_state` for Keplerian input, `cartesian_state` for Cartesian input).

### 8. Unrecognised gravity string in `Particle` and `System` raised `UnboundLocalError` — `particle.py`, `system.py`

If a user passed an unrecognised gravity string (e.g. `gravity="default"` instead of
`"default solar system"`), none of the `if/elif` branches in `_setup_acceleration_func`
matched, `acc_func` was never assigned, and `return acc_func` raised an opaque
`UnboundLocalError: local variable 'acc_func' referenced before assignment`. The fix
adds an `else: raise ValueError(...)` with a clear list of valid options to both
`Particle._setup_acceleration_func` and `System._setup_acceleration_func`.

---

## Non-code issues documented (no fix needed)

### 5. Custom gravity function epoch contract — `particle.py`, `system.py`

The wrappers for user-supplied `gravity=jax.tree_util.Partial(...)` functions
shift `state.time` by `self._t_ref_jd` to recover absolute JD before calling
the user's function. This is correct only if the function was built with
`t_ref_jd=0`. Passing a jorbit factory function built with a non-zero
`t_ref_jd` would double-count the offset and silently query the ephemeris at
the wrong time. The required contract is now documented in a comment with a
safe usage example.

### 6. `simple_circular` fit-seed time — `particle.py`

When there are fewer than 3 observations, the fit seed is generated with
`time=self._t_ref_jd` (the Particle's reference epoch). This is intentional:
the optimizer treats the seed's `x, v` as the state at `self._t_ref_jd`, so
the seed must be computed at that epoch. A comment was added to prevent a
future well-intentioned change to `obs.times[0]` that would silently mismatch
the epoch the optimizer expects.

---

## New tests added

### `tests/test_end_to_end.py` (new file, 12 tests)

| Test | Covers |
|---|---|
| `test_observations_getitem_integer_preserves_times_astropy` | Fix 1 regression |
| `test_observations_getitem_slice_preserves_times_astropy` | Fix 1 regression |
| `test_observations_sliced_then_added_preserves_times_astropy` | Fit-seed slice/combine pipeline |
| `test_system_from_systemstate_with_float_time_raises` | Fix 2 regression |
| `test_system_from_particles_has_correct_epoch` | Correct System construction |
| `test_system_from_particles_integrates_consistently` | System/Particle position agreement |
| `test_heliocentric_barycentric_cartesian_roundtrip` | Fix 3 regression (Cartesian) |
| `test_heliocentric_barycentric_keplerian_roundtrip` | Fix 3 regression (Keplerian) |
| `test_observations_prebuilt_covariance_matrix` | Fix 4, previously untested path |
| `test_particle_from_state_with_nonzero_relative_time` | Epoch from `relative_time + time_reference` |
| `test_self_consistent_observations_static_residuals_finite` | End-to-end: self-consistent orbit → finite static residuals |
| `test_static_and_dynamic_residuals_agree` | Static/dynamic pipeline consistency (< 0.1 mas) |

### `tests/test_observation.py` (3 tests added)

| Test | Covers |
|---|---|
| `test_add_preserves_covariance_consistency` | `inv_cov @ cov = I` after `__add__` |
| `test_single_observation_init` | Single-observation initialization |
| `test_getitem_negative_index` | Negative index slicing |
