### PR TITLE
Feature/de truncate public integration

### DIFF
--- a/docs/user_guide/changelog.rst
+++ b/docs/user_guide/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 +++++++++
 
+**development version**
+
+- Added protections for integrations/ephemerides generated via the front end `Particle` and `System` classes no longer silently truncate when an integration requires more steps than allocated in 1) the cap of 10k steps between time steps and 2) the cap of 15k total accepted steps when using "interpolation". The actual caps remain in the back end implementations.
+
 **1.4.0 (05/2026)**
 
 - Added `uncertainty=True` as an option to `Particle.ephemeris` that returns the propagated on-sky covariance in addition to the propagated state. This is implemented by computing the Jacobian of the dynamics using forward autodiff, then linear error propagation using the initial covariance on the `CartesianState` or `KeplerianState`.

--- a/src/jorbit/integrators/__init__.py
+++ b/src/jorbit/integrators/__init__.py
@@ -1,10 +1,12 @@
 """All functions related to integrating a SystemState."""
 
 __all__ = [
+    "budgeted_forced_landing",
     "create_leapfrog_times",
     "ias15_evolve",
     "ias15_evolve_forced_landing",
     "ias15_evolve_with_dense_output",
+    "ias15_span_probe",
     "ias15_static_evolve",
     "ias15_static_step",
     "ias15_step",
@@ -16,8 +18,16 @@ __all__ = [
     "next_proposed_dt_PRS23",
     "next_proposed_dt_global",
     "precompute_interpolation_indices",
+    "stitched_interpolate",
+    "stitched_per_query_gather",
 ]
 
+from jorbit.integrators.budgeted import (
+    budgeted_forced_landing,
+    ias15_span_probe,
+    stitched_interpolate,
+    stitched_per_query_gather,
+)
 from jorbit.integrators.ias15 import (
     ias15_evolve,
     ias15_evolve_forced_landing,

--- a/src/jorbit/integrators/budgeted.py
+++ b/src/jorbit/integrators/budgeted.py
@@ -1,0 +1,415 @@
+"""Front-end orchestration that keeps IAS15 integrations off the backend buffers.
+
+The IAS15 backends in :mod:`jorbit.integrators.ias15` are deliberately hard-capped so
+that their buffers stay bounded and JIT-friendly:
+
+- the interpolation path (:func:`ias15_evolve` / :func:`ias15_evolve_with_dense_output`)
+  stores per-step dense output in a buffer of ``IAS15_MAX_DYNAMIC_STEPS`` (15000) steps,
+  and
+- the forced-landing path (:func:`ias15_evolve_forced_landing`) caps the number of
+  steps *between* consecutive requested times at 10000.
+
+Past those caps the backends silently truncate. Keeping the caps is the right call for
+the bounded JIT kernels, but the public ``Particle``/``System`` methods should never
+hand a user a silently-truncated answer. This module sits on top of the (unchanged)
+backends and does extra, data-dependent work on the host so that the nominal public
+methods are truncation-proof:
+
+- :func:`stitched_per_query_gather` stitches successive interpolation chunks together,
+  carrying the integrator state forward so the result is bit-identical to a single run
+  with a larger buffer.
+- :func:`budgeted_forced_landing` detects a truncating forced-landing run and inserts
+  "dummy" landing times (dropped from the output afterward) so no single interval
+  exceeds the backend's per-interval cap. This mirrors the existing
+  :func:`jorbit.integrators.create_leapfrog_times` "expand then select" pattern.
+
+None of these helpers is JIT'd: the public methods that call them already produce host
+objects (e.g. ``SkyCoord``), so a short host-side loop over JIT'd backend calls is fine.
+The common case is a single backend call plus one cheap scalar check.
+"""
+
+from collections.abc import Callable, Iterator
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+
+from jorbit.integrators.ias15 import (
+    ias15_evolve,
+    ias15_evolve_forced_landing,
+    ias15_evolve_with_dense_output,
+    interpolate_from_dense_output,
+)
+from jorbit.utils.states import IAS15IntegratorState, SystemState
+
+# Tolerance (days) for "did the integrator reach this time" comparisons. ~0.1 ms, far
+# below any meaningful step size, so it only absorbs floating-point round-trips.
+_TIME_TOL = 1e-9
+
+# Natural-step budget per forced-landing interval. The backend caps a single interval at
+# 10000 *iterations* (accepted + rejected); we budget on accepted natural steps and keep
+# generous headroom for the occasional rejected step plus the clamp step each dummy adds.
+FORCED_LANDING_STEP_BUDGET = 8000
+
+# Sentinel value used by the backend to fill unused dense-output slots (see ias15.py).
+_DTS_SENTINEL = 1e29
+
+
+def _iterate_evolve_chunks(
+    initial_system_state: SystemState,
+    acceleration_func: Callable,
+    times: jnp.ndarray,
+    initial_integrator_state: IAS15IntegratorState,
+    step_scheduler: Callable,
+) -> Iterator[tuple]:
+    """Yield successive dense-output chunks until the integration reaches ``max(times)``.
+
+    Each chunk is a full :func:`ias15_evolve_with_dense_output` run (the full ``times``
+    array is passed every chunk, so the kernel compiles once and is reused). The final
+    state/integrator state of each chunk seed the next, which continues the adaptive
+    sequence bit-identically. Raises if a chunk fails to make forward progress (e.g. a
+    NaN acceleration), so the loop can never spin forever or silently truncate.
+
+    Yields:
+        ``(chunk_output, chunk_start, t_reached, direction)`` per chunk, where
+        ``chunk_output`` is the full 13-tuple from
+        :func:`ias15_evolve_with_dense_output`.
+    """
+    state = initial_system_state
+    integrator_state = initial_integrator_state
+    target = float(jnp.max(times))
+    t0 = float(state.relative_time)
+    direction = 0.0
+    chunk_start = t0
+
+    while True:
+        out = ias15_evolve_with_dense_output(
+            state, acceleration_func, times, integrator_state, step_scheduler
+        )
+        final_system_state = out[2]
+        t_reached = float(final_system_state.relative_time)
+
+        if direction == 0.0:
+            direction = 1.0 if (t_reached - t0) >= 0.0 else -1.0
+
+        yield out, chunk_start, t_reached, direction
+
+        # Reached the farthest requested time -> done.
+        if direction * (t_reached - target) >= -_TIME_TOL:
+            return
+
+        # No forward progress despite not having reached the target -> genuinely stuck.
+        if direction * (t_reached - chunk_start) <= _TIME_TOL:
+            raise RuntimeError(
+                "IAS15 interpolation stitching made no forward progress at "
+                f"relative_time={t_reached} (target={target}). The integration may be "
+                "stuck (e.g. a NaN acceleration or a degenerate step). This is a "
+                "genuine failure, not a buffer truncation."
+            )
+
+        state = out[2]
+        integrator_state = out[3]
+        chunk_start = t_reached
+
+
+def stitched_per_query_gather(
+    initial_system_state: SystemState,
+    acceleration_func: Callable,
+    times: jnp.ndarray,
+    initial_integrator_state: IAS15IntegratorState,
+    step_scheduler: Callable,
+) -> tuple:
+    """Gather per-query dense-output slices across as many chunks as needed (no cap).
+
+    For each requested time this returns the converged 7th-order ``b`` coefficients plus
+    the start-of-step ``a0``/``x0``/``v0``, the step length ``dt``, and the fractional
+    position ``h`` of the query within its step, drawn from whichever stitched chunk
+    actually covers that time. The result is exactly what a single
+    :func:`ias15_evolve_with_dense_output` call would return for those times if its
+    buffer were large enough, but with no silent truncation.
+
+    Feed the gather to :func:`interpolate_from_dense_output` for positions/velocities, or
+    to :func:`jorbit.integrators.make_ltt_propagator` for dense-output ephemerides.
+
+    Returns:
+        ``(b_q, a0_q, x0_q, v0_q, dt_q, h_q, total_steps)``. With ``n = len(times)`` and
+        ``P`` particles: ``b_q`` is ``(n, 7, P, 3)``; ``a0_q``/``x0_q``/``v0_q`` are
+        ``(n, P, 3)``; ``dt_q``/``h_q`` are ``(n,)``; ``total_steps`` is the summed
+        iteration count across all chunks.
+    """
+    n_times = times.shape[0]
+    b_q = a0_q = x0_q = v0_q = dt_q = h_q = None
+    covered = jnp.zeros(n_times, dtype=bool)
+    total_steps = 0
+
+    for out, _chunk_start, t_reached, direction in _iterate_evolve_chunks(
+        initial_system_state,
+        acceleration_func,
+        times,
+        initial_integrator_state,
+        step_scheduler,
+    ):
+        (
+            _positions,
+            _velocities,
+            _final_system_state,
+            _final_integrator_state,
+            iter_num,
+            b_buf,
+            a0_buf,
+            x0_buf,
+            v0_buf,
+            dts_buf,
+            _t_step_starts,
+            step_indices,
+            h_values,
+        ) = out
+        total_steps += int(iter_num)
+
+        if b_q is None:
+            # Allocate accumulators now that we know the per-step shapes.
+            b_q = jnp.zeros((n_times, *b_buf.shape[1:]))
+            a0_q = jnp.zeros((n_times, *a0_buf.shape[1:]))
+            x0_q = jnp.zeros((n_times, *x0_buf.shape[1:]))
+            v0_q = jnp.zeros((n_times, *v0_buf.shape[1:]))
+            dt_q = jnp.zeros((n_times,))
+            h_q = jnp.zeros((n_times,))
+
+        # Times this chunk newly covers: not yet covered and at/before t_reached in the
+        # integration direction. Already-covered times keep their earlier gather; times
+        # past t_reached are left for a later chunk.
+        reached = direction * (t_reached - times) >= -_TIME_TOL
+        newly = (~covered) & reached
+
+        b_chunk = b_buf[step_indices]
+        a0_chunk = a0_buf[step_indices]
+        x0_chunk = x0_buf[step_indices]
+        v0_chunk = v0_buf[step_indices]
+        dt_chunk = dts_buf[step_indices]
+
+        b_q = jnp.where(newly[:, None, None, None], b_chunk, b_q)
+        a0_q = jnp.where(newly[:, None, None], a0_chunk, a0_q)
+        x0_q = jnp.where(newly[:, None, None], x0_chunk, x0_q)
+        v0_q = jnp.where(newly[:, None, None], v0_chunk, v0_q)
+        dt_q = jnp.where(newly, dt_chunk, dt_q)
+        h_q = jnp.where(newly, h_values, h_q)
+
+        covered = covered | newly
+
+    return b_q, a0_q, x0_q, v0_q, dt_q, h_q, total_steps
+
+
+def stitched_interpolate(
+    initial_system_state: SystemState,
+    acceleration_func: Callable,
+    times: jnp.ndarray,
+    initial_integrator_state: IAS15IntegratorState,
+    step_scheduler: Callable,
+) -> tuple[jnp.ndarray, jnp.ndarray, int]:
+    """Interpolated positions/velocities at ``times``, stitched to avoid the 15k buffer.
+
+    Drop-in replacement for the interpolation-path :func:`ias15_evolve` call used by the
+    public ``integrate_or_interpolate`` / ``System.integrate`` methods.
+
+    Returns:
+        ``(positions, velocities, total_steps)`` with positions/velocities of shape
+        ``(len(times), P, 3)``.
+    """
+    b_q, a0_q, x0_q, v0_q, dt_q, h_q, total_steps = stitched_per_query_gather(
+        initial_system_state,
+        acceleration_func,
+        times,
+        initial_integrator_state,
+        step_scheduler,
+    )
+    # interpolate_from_dense_output indexes its buffers by step_indices; the gather is
+    # already per-query, so identity indices recover one polynomial evaluation per time.
+    identity = jnp.arange(times.shape[0])
+    positions, velocities = interpolate_from_dense_output(
+        b_q, a0_q, x0_q, v0_q, dt_q, identity, h_q
+    )
+    return positions, velocities, total_steps
+
+
+def discover_natural_step_times(
+    initial_system_state: SystemState,
+    acceleration_func: Callable,
+    times: jnp.ndarray,
+    initial_integrator_state: IAS15IntegratorState,
+    step_scheduler: Callable,
+) -> jnp.ndarray:
+    """Cumulative end-times of every natural adaptive step from ``t0`` past ``max(times)``.
+
+    Unlike :func:`jorbit.accelerations.static_helpers.get_natural_dynamic_dts` (a slow
+    per-step Python loop capped at 10000 steps), this rides the fast JIT'd chunk loop and
+    is uncapped. Used to place forced-landing dummy times at natural step boundaries.
+    """
+    all_dts = []
+    for out, _chunk_start, _t_reached, _direction in _iterate_evolve_chunks(
+        initial_system_state,
+        acceleration_func,
+        times,
+        initial_integrator_state,
+        step_scheduler,
+    ):
+        dts_buf = out[9]
+        # Keep only the filled prefix; unused slots hold the large sentinel.
+        valid = dts_buf[dts_buf < _DTS_SENTINEL]
+        all_dts.append(valid)
+
+    t0 = initial_system_state.relative_time
+    dts = jnp.concatenate(all_dts) if all_dts else jnp.array([])
+    return t0 + jnp.cumsum(dts)
+
+
+def insert_budget_dummy_times(
+    natural_step_times: jnp.ndarray,
+    requested_times: jnp.ndarray,
+    t0: float,
+    budget: int,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Insert dummy landing times so no requested interval holds more than ``budget`` steps.
+
+    Mirrors the contract of :func:`jorbit.integrators.create_leapfrog_times`: returns an
+    expanded, ascending time array plus the indices of the original ``requested_times``
+    within it. Dummy times are placed at natural step boundaries inside any interval that
+    would otherwise exceed ``budget`` natural steps.
+
+    Args:
+        natural_step_times: Cumulative natural step end-times from
+            :func:`discover_natural_step_times`.
+        requested_times: The originally requested output times.
+        t0: Integration start time (offset frame).
+        budget: Maximum natural steps allowed per (sub-)interval.
+
+    Returns:
+        ``(augmented_times, relevant_inds)``.
+    """
+    nst = jnp.asarray(natural_step_times)
+    augmented = []
+    relevant_inds = []
+    prev = float(t0)
+
+    for tq in [float(t) for t in requested_times]:
+        lo, hi = (prev, tq) if tq >= prev else (tq, prev)
+        # Natural step boundaries strictly inside this interval, in integration order.
+        interior = nst[(nst > lo) & (nst < hi)]
+        if tq < prev:
+            interior = interior[::-1]
+        n = int(interior.shape[0])
+        if n > budget:
+            for k in range(budget, n, budget):
+                augmented.append(float(interior[k]))
+        augmented.append(tq)
+        relevant_inds.append(len(augmented) - 1)
+        prev = tq
+
+    return jnp.array(augmented), jnp.array(relevant_inds, dtype=int)
+
+
+def budgeted_forced_landing(
+    initial_system_state: SystemState,
+    acceleration_func: Callable,
+    times: jnp.ndarray,
+    initial_integrator_state: IAS15IntegratorState,
+    step_scheduler: Callable,
+) -> tuple[jnp.ndarray, jnp.ndarray, int]:
+    """Forced-landing integration that never silently truncates between requested times.
+
+    Runs :func:`ias15_evolve_forced_landing` on ``times``; if any interval truncated (the
+    integrator failed to reach the last requested time), discovers the natural step
+    structure, inserts dummy landing times so each sub-interval stays under the backend's
+    per-interval cap, and re-runs. The dummy times are dropped from the returned arrays.
+
+    Inserting a dummy landing splits one step into two clamped steps, a perturbation of
+    the same kind forced-landing already incurs at every requested time and far below the
+    mas-level accuracy target; the budget margin absorbs the extra clamp steps.
+
+    Returns:
+        ``(positions, velocities, total_steps)`` at the originally requested ``times``.
+    """
+    positions, velocities, final_system_state, _final_integrator_state, tot_steps = (
+        ias15_evolve_forced_landing(
+            initial_system_state,
+            acceleration_func,
+            times,
+            initial_integrator_state,
+            step_scheduler,
+        )
+    )
+
+    last_time = float(times[-1])
+    t0 = float(initial_system_state.relative_time)
+    direction = 1.0 if last_time >= t0 else -1.0
+    reached = (
+        direction * (float(final_system_state.relative_time) - last_time) >= -_TIME_TOL
+    )
+    if reached:
+        return positions, velocities, int(tot_steps)
+
+    # A run truncated somewhere; targets only advance, so a short final time is a
+    # reliable signal. Discover the natural step density and subdivide.
+    natural_step_times = discover_natural_step_times(
+        initial_system_state,
+        acceleration_func,
+        times,
+        initial_integrator_state,
+        step_scheduler,
+    )
+    augmented_times, relevant_inds = insert_budget_dummy_times(
+        natural_step_times, times, t0, FORCED_LANDING_STEP_BUDGET
+    )
+    positions, velocities, final_system_state, _final_integrator_state, tot_steps = (
+        ias15_evolve_forced_landing(
+            initial_system_state,
+            acceleration_func,
+            augmented_times,
+            initial_integrator_state,
+            step_scheduler,
+        )
+    )
+
+    last_aug = float(augmented_times[-1])
+    if direction * (float(final_system_state.relative_time) - last_aug) < -_TIME_TOL:
+        # Essentially unreachable (would require a single ~8000-natural-step sub-interval
+        # to still overflow the 10000-iteration cap). Raise rather than silently truncate.
+        raise RuntimeError(
+            "Forced-landing integration still truncated after inserting dummy landing "
+            "times. Try integrate_or_interpolate (interpolation path) instead, or "
+            "request more closely spaced output times."
+        )
+    return positions[relevant_inds], velocities[relevant_inds], int(tot_steps)
+
+
+def ias15_span_probe(
+    initial_system_state: SystemState,
+    acceleration_func: Callable,
+    times: jnp.ndarray,
+    initial_integrator_state: IAS15IntegratorState,
+    step_scheduler: Callable,
+) -> tuple[bool, int]:
+    """Probe a single nominal :func:`ias15_evolve` chunk over ``times``.
+
+    Returns ``(would_truncate, total_steps)`` where ``would_truncate`` is True if one
+    dense-output buffer fails to reach ``max(times)``. A cheap forward integration (no
+    autodiff) used by the detect-and-raise guards on the covariance-ephemeris and
+    likelihood paths, where the host-side stitching loop cannot be threaded through
+    ``jax.jacfwd``.
+    """
+    out = ias15_evolve(
+        initial_system_state,
+        acceleration_func,
+        times,
+        initial_integrator_state,
+        step_scheduler,
+    )
+    final_system_state = out[2]
+    total_steps = int(out[4])
+    target = float(jnp.max(times))
+    t0 = float(initial_system_state.relative_time)
+    direction = 1.0 if target >= t0 else -1.0
+    would_truncate = bool(
+        direction * (float(final_system_state.relative_time) - target) < -_TIME_TOL
+    )
+    return would_truncate, total_steps

--- a/src/jorbit/particle.py
+++ b/src/jorbit/particle.py
@@ -43,15 +43,19 @@ from jorbit.data.constants import (
 )
 from jorbit.ephemeris.ephemeris import Ephemeris
 from jorbit.integrators import (
+    budgeted_forced_landing,
     create_leapfrog_times,
     ias15_evolve,
     ias15_evolve_forced_landing,
     ias15_evolve_with_dense_output,
+    ias15_span_probe,
     initialize_ias15_integrator_state,
     leapfrog_evolve,
     make_ltt_propagator,
     next_proposed_dt_global,
     next_proposed_dt_PRS23,
+    stitched_interpolate,
+    stitched_per_query_gather,
 )
 from jorbit.likelihoods.setup_static_likelihood import (
     create_default_static_residuals_func,
@@ -840,16 +844,12 @@ class Particle:
             times = jnp.array([times])
 
         if self._integrator_method in ["Y4", "Y6", "Y8"]:
+            # Leapfrog pre-expands its (uncapped) time array, so it never truncates.
             times, inds = create_leapfrog_times(
                 state.relative_time, times, self._max_step_size
             )
-        else:
-            inds = jnp.arange(times.shape[0])
-
-        integrator = self._forced_integrator if forced_landing else self._integrator
-
-        positions, velocities, _final_system_state, _final_integrator_state, steps = (
-            _integrate(
+            integrator = self._forced_integrator if forced_landing else self._integrator
+            positions, velocities, _fss, _fis, steps = _integrate(
                 times,
                 state,
                 self.gravity,
@@ -858,7 +858,20 @@ class Particle:
                 inds,
                 self._step_scheduler,
             )
-        )
+            return positions[:, 0, :], velocities[:, 0, :], steps
+
+        # IAS15: orchestrate on the host so neither the dense-output buffer
+        # (interpolation) nor the per-interval cap (forced landing) can silently
+        # truncate. See jorbit.integrators.budgeted.
+        sys_state = state.to_system()
+        if forced_landing:
+            positions, velocities, steps = budgeted_forced_landing(
+                sys_state, self.gravity, times, integrator_state, self._step_scheduler
+            )
+        else:
+            positions, velocities, steps = stitched_interpolate(
+                sys_state, self.gravity, times, integrator_state, self._step_scheduler
+            )
         return positions[:, 0, :], velocities[:, 0, :], steps
 
     def integrate(
@@ -941,7 +954,8 @@ class Particle:
         state: CartesianState | KeplerianState | None = None,
         interpolate: bool = True,
         uncertainty: bool = False,
-    ) -> SkyCoord | tuple[SkyCoord, jnp.ndarray]:
+        return_steps: bool = False,
+    ) -> SkyCoord | tuple:
         """Compute an ephemeris for the particle.
 
         Args:
@@ -967,16 +981,24 @@ class Particle:
                 between parameterizations is performed. Expect roughly a ``6x`` cost
                 relative to the nominal call because ``jax.jacfwd`` performs one JVP
                 evaluation per input dimension. Defaults to False.
+            return_steps (bool):
+                If True, also return the total number of integration steps taken (summed
+                across any stitched interpolation chunks / inserted forced-landing
+                landings). Appended as the final element of the returned tuple. For the
+                IAS15 integrator this is the figure to watch: the nominal ephemeris is
+                truncation-proof, but the count reveals an unusually heavy integration.
+                ``None`` for the analytic Keplerian and fixed-step leapfrog paths, which
+                cannot truncate. Defaults to False.
 
         Returns:
-            coords (SkyCoord | tuple[SkyCoord, jnp.ndarray]):
+            coords (SkyCoord | tuple):
                 If ``uncertainty=False`` (default), returns a SkyCoord with the
                 ephemeris of the particle at the given times, in ICRS coordinates, as
                 seen from that specific observer and correcting for light travel time.
                 If ``uncertainty=True``, returns a tuple with the same SkyCoord and the
-                propagated ``(N, 2, 2)`` sky-plane covariance in ``arcsec**2``,
-                (the propagated ``(N, 2, 2)`` sky-plane covariance in ``arcsec**2``,
-                axis order (RA, Dec)).
+                propagated ``(N, 2, 2)`` sky-plane covariance in ``arcsec**2``
+                (axis order (RA, Dec)). If ``return_steps=True``, the step count is
+                appended as the final tuple element.
         """
         if isinstance(observer, str):
             observer_positions = get_observer_positions(
@@ -1018,7 +1040,11 @@ class Particle:
                 ras, decs, cov_radec = _keplerian_ephem_with_cov(
                     kep_state, offsets, observer_positions, cov
                 )
-                return (SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs"), cov_radec)
+                coords = SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs")
+                # Keplerian propagation is analytic: no integration steps to report.
+                if return_steps:
+                    return (coords, cov_radec, None)
+                return (coords, cov_radec)
 
             if state is not None:
                 state = state.to_cartesian()
@@ -1031,7 +1057,10 @@ class Particle:
                 x, v, t0 = self._x, self._v, self._time
 
             ras, decs = _keplerian_ephem(x, v, t0, offsets, observer_positions)
-            return SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs")
+            coords = SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs")
+            if return_steps:
+                return (coords, None)
+            return coords
 
         if state is None:
             state = self._cartesian_state
@@ -1052,16 +1081,35 @@ class Particle:
             inds = jnp.arange(times.shape[0])
 
         integrator = self._integrator if interpolate else self._forced_integrator
+        is_leapfrog = self._integrator_method in ("Y4", "Y6", "Y8")
         # IAS15 with interpolation has dense-output b-coefficients available, so
         # we can use them to evaluate the polynomial at light-travel-delayed times in on_sky's
         # LTT loop instead of a constant-acceleration Taylor expansion. All other
         # paths (leapfrog, IAS15 forced-landing) fall back to the original Taylor.
-        use_dense_ltt = interpolate and self._integrator_method not in (
-            "Y4",
-            "Y6",
-            "Y8",
-        )
+        use_dense_ltt = interpolate and not is_leapfrog
+
         if uncertainty:
+            # The covariance path runs the integration inside jax.jacfwd, which cannot
+            # be threaded through the host-side stitching loop. For IAS15, detect a span
+            # that would overflow the dense-output buffer and raise rather than silently
+            # truncate (a nominal ephemeris() call auto-handles the same span).
+            steps = None
+            if not is_leapfrog:
+                would_truncate, steps = ias15_span_probe(
+                    state.to_system(),
+                    self.gravity,
+                    times,
+                    integrator_state,
+                    self._step_scheduler,
+                )
+                if would_truncate:
+                    raise RuntimeError(
+                        "ephemeris(uncertainty=True) over this span would exceed the "
+                        "IAS15 dense-output buffer and silently truncate. The covariance "
+                        "path uses forward-mode autodiff and cannot be transparently "
+                        "stitched; request a shorter span or more closely spaced times. "
+                        "(A nominal ephemeris(uncertainty=False) call auto-handles this.)"
+                    )
             if use_dense_ltt:
                 ras, decs, cov_radec = _ephem_ias15_with_cov(
                     times,
@@ -1084,10 +1132,24 @@ class Particle:
                     self._step_scheduler,
                     cov,
                 )
-            return (SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs"), cov_radec)
+            coords = SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs")
+            if return_steps:
+                return (coords, cov_radec, steps)
+            return (coords, cov_radec)
 
         if use_dense_ltt:
-            ras, decs = _ephem_ias15(
+            ras, decs, steps = _ephem_ias15_stitched(
+                times,
+                state,
+                self.gravity,
+                integrator_state,
+                observer_positions,
+                inds,
+                self._step_scheduler,
+            )
+        elif not is_leapfrog:
+            # IAS15 forced-landing (interpolate=False): Taylor-LTT on budgeted landings.
+            ras, decs, steps = _ephem_forced_budgeted(
                 times,
                 state,
                 self.gravity,
@@ -1107,7 +1169,11 @@ class Particle:
                 inds,
                 self._step_scheduler,
             )
-        return SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs")
+            steps = None
+        coords = SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs")
+        if return_steps:
+            return (coords, steps)
+        return coords
 
     def max_likelihood(
         self,
@@ -1140,6 +1206,37 @@ class Particle:
                 fit_seed.to_cartesian().v.flatten(),
             ]
         )
+
+        if (not self._is_keplerian) and self._integrator_method == "ias15":
+            # Best-effort detect-and-raise guard. The likelihood integrates the
+            # observation span with the interpolation path (the 15k dense-output
+            # buffer). The orbit changes during optimization, but if even the seed
+            # already overflows the buffer the fit would silently truncate. Orbit
+            # fitting runs inside forward-mode autodiff and so cannot be transparently
+            # stitched the way the nominal integrate/ephemeris methods are.
+            seed_state = CartesianState(
+                x=jnp.array([x0[:3]]),
+                v=jnp.array([x0[3:]]),
+                relative_time=self._time,
+                time_reference=self._t_ref_jd,
+                acceleration_func_kwargs=self._acc_func_kwargs,
+            )
+            obs_times = self._observations_times_as_offsets()
+            a0 = self.gravity(seed_state.to_system())
+            would_truncate, _steps = ias15_span_probe(
+                seed_state.to_system(),
+                self.gravity,
+                obs_times,
+                initialize_ias15_integrator_state(a0),
+                self._step_scheduler,
+            )
+            if would_truncate:
+                raise RuntimeError(
+                    "The observation time span would exceed the IAS15 dense-output "
+                    "buffer and silently truncate the likelihood integration. Orbit "
+                    "fitting runs inside forward-mode autodiff and cannot be "
+                    "transparently stitched; fit over a shorter arc or split the data."
+                )
 
         if self._is_keplerian:
             # Keplerian propagation produces NaN for hyperbolic orbits, so we
@@ -1368,53 +1465,26 @@ def _ephem(
 
 
 @jax.jit
-def _ephem_ias15(
-    times: jnp.ndarray,
-    particle_state: CartesianState | KeplerianState,
-    acc_func: Callable,
-    integrator_state: IAS15IntegratorState,
+def _dense_ltt_radec(
+    b_per_obs: jnp.ndarray,
+    a0_per_obs: jnp.ndarray,
+    x0_per_obs: jnp.ndarray,
+    v0_per_obs: jnp.ndarray,
+    dt_per_obs: jnp.ndarray,
+    h_per_obs: jnp.ndarray,
+    obs_times: jnp.ndarray,
     observer_positions: jnp.ndarray,
-    relevant_inds: jnp.ndarray,
-    step_scheduler: Callable,
+    acc_func: Callable,
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
-    """IAS15-only variant of ``_ephem`` that uses dense-output b-coefficients for LTT.
+    """Per-observation dense-output light-travel-time ``on_sky`` for a single particle.
 
     The ``on_sky`` light-travel-time correction defaults to a 2nd-order Taylor with a
-    constant acceleration. For IAS15, we already have the converged 7th-order
-    polynomial per step (the "dense output"). This variant builds a per-observation
-    closure that evaluates that polynomial at the light-travel-delayed time, replacing the
-    Taylor expansion. Only used when ``interpolate=True``.
+    constant acceleration. For IAS15 we already have the converged 7th-order polynomial
+    per step (the "dense output"), so this evaluates that polynomial at the
+    light-travel-delayed time instead. Inputs are already gathered per observation:
+    ``b_per_obs`` is ``(n, 7, 3)``; ``a0/x0/v0_per_obs`` are ``(n, 3)``;
+    ``dt/h_per_obs/obs_times`` are ``(n,)``; ``observer_positions`` is ``(n, 3)``.
     """
-    state = particle_state.to_system()
-    (
-        _positions,
-        _velocities,
-        _final_system_state,
-        _final_integrator_state,
-        _iter_num,
-        b_buf,
-        a0_buf,
-        x0_buf,
-        v0_buf,
-        dts_buf,
-        _t_step_starts,
-        step_indices,
-        h_values,
-    ) = ias15_evolve_with_dense_output(
-        state, acc_func, times, integrator_state, step_scheduler
-    )
-
-    # Restrict to observation times only (drops any intermediate landing times).
-    obs_times = times[relevant_inds]
-    obs_step_indices = step_indices[relevant_inds]
-    obs_h_values = h_values[relevant_inds]
-
-    # Per-obs dense-output gather (single tracer at index 0).
-    b_per_obs = b_buf[obs_step_indices][:, :, 0, :]
-    a0_per_obs = a0_buf[obs_step_indices][:, 0, :]
-    x0_per_obs = x0_buf[obs_step_indices][:, 0, :]
-    v0_per_obs = v0_buf[obs_step_indices][:, 0, :]
-    dt_per_obs = dts_buf[obs_step_indices]
 
     def per_obs_on_sky(
         b_step: jnp.ndarray,
@@ -1439,17 +1509,160 @@ def _ephem_ias15(
             ltt_position_fn=propagator,
         )
 
-    ras, decs = jax.vmap(per_obs_on_sky, in_axes=(0, 0, 0, 0, 0, 0, 0, 0))(
+    return jax.vmap(per_obs_on_sky, in_axes=(0, 0, 0, 0, 0, 0, 0, 0))(
         b_per_obs,
         a0_per_obs,
         x0_per_obs,
         v0_per_obs,
         dt_per_obs,
-        obs_h_values,
+        h_per_obs,
         obs_times,
         observer_positions,
     )
+
+
+@jax.jit
+def _on_sky_scan(
+    positions: jnp.ndarray,
+    velocities: jnp.ndarray,
+    times: jnp.ndarray,
+    observer_positions: jnp.ndarray,
+    acc_func: Callable,
+    time_reference: jnp.ndarray,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Scan the (Taylor-LTT) ``on_sky`` over a sequence of single-particle states."""
+
+    def scan_func(carry: None, scan_over: tuple) -> tuple[None, tuple]:
+        position, velocity, time, observer_position = scan_over
+        ra, dec = on_sky(
+            position,
+            velocity,
+            time,
+            observer_position,
+            acc_func,
+            time_reference=time_reference,
+        )
+        return None, (ra, dec)
+
+    _, (ras, decs) = jax.lax.scan(
+        scan_func, None, (positions, velocities, times, observer_positions)
+    )
     return ras, decs
+
+
+@jax.jit
+def _ephem_ias15(
+    times: jnp.ndarray,
+    particle_state: CartesianState | KeplerianState,
+    acc_func: Callable,
+    integrator_state: IAS15IntegratorState,
+    observer_positions: jnp.ndarray,
+    relevant_inds: jnp.ndarray,
+    step_scheduler: Callable,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Single-chunk IAS15 dense-output ephemeris (used inside the autodiff cov path).
+
+    The truncation-proof nominal ephemeris uses :func:`_ephem_ias15_stitched` instead;
+    this single-:func:`ias15_evolve_with_dense_output` version is retained because it is
+    fully JIT-able and so can be wrapped by ``jax.jacfwd`` in
+    :func:`_ephem_ias15_with_cov`.
+    """
+    state = particle_state.to_system()
+    (
+        _positions,
+        _velocities,
+        _final_system_state,
+        _final_integrator_state,
+        _iter_num,
+        b_buf,
+        a0_buf,
+        x0_buf,
+        v0_buf,
+        dts_buf,
+        _t_step_starts,
+        step_indices,
+        h_values,
+    ) = ias15_evolve_with_dense_output(
+        state, acc_func, times, integrator_state, step_scheduler
+    )
+
+    # Restrict to observation times only (drops any intermediate landing times).
+    obs_step_indices = step_indices[relevant_inds]
+    return _dense_ltt_radec(
+        b_buf[obs_step_indices][:, :, 0, :],
+        a0_buf[obs_step_indices][:, 0, :],
+        x0_buf[obs_step_indices][:, 0, :],
+        v0_buf[obs_step_indices][:, 0, :],
+        dts_buf[obs_step_indices],
+        h_values[relevant_inds],
+        times[relevant_inds],
+        observer_positions,
+        acc_func,
+    )
+
+
+def _ephem_ias15_stitched(
+    times: jnp.ndarray,
+    particle_state: CartesianState | KeplerianState,
+    acc_func: Callable,
+    integrator_state: IAS15IntegratorState,
+    observer_positions: jnp.ndarray,
+    relevant_inds: jnp.ndarray,
+    step_scheduler: Callable,
+) -> tuple[jnp.ndarray, jnp.ndarray, int]:
+    """Truncation-proof IAS15 dense-output ephemeris (nominal ``interpolate=True``).
+
+    Host-side wrapper that stitches as many dense-output chunks as the span requires
+    (see :func:`jorbit.integrators.stitched_per_query_gather`) before the same per-obs
+    dense-LTT ``on_sky`` evaluation as :func:`_ephem_ias15`.
+    """
+    state = particle_state.to_system()
+    b_q, a0_q, x0_q, v0_q, dt_q, h_q, steps = stitched_per_query_gather(
+        state, acc_func, times, integrator_state, step_scheduler
+    )
+    # Single tracer at index 0; restrict to observation times.
+    ras, decs = _dense_ltt_radec(
+        b_q[relevant_inds][:, :, 0, :],
+        a0_q[relevant_inds][:, 0, :],
+        x0_q[relevant_inds][:, 0, :],
+        v0_q[relevant_inds][:, 0, :],
+        dt_q[relevant_inds],
+        h_q[relevant_inds],
+        times[relevant_inds],
+        observer_positions,
+        acc_func,
+    )
+    return ras, decs, steps
+
+
+def _ephem_forced_budgeted(
+    times: jnp.ndarray,
+    particle_state: CartesianState | KeplerianState,
+    acc_func: Callable,
+    integrator_state: IAS15IntegratorState,
+    observer_positions: jnp.ndarray,
+    relevant_inds: jnp.ndarray,
+    step_scheduler: Callable,
+) -> tuple[jnp.ndarray, jnp.ndarray, int]:
+    """Truncation-proof IAS15 forced-landing ephemeris (nominal ``interpolate=False``).
+
+    Host-side wrapper that inserts dummy landing times as needed (see
+    :func:`jorbit.integrators.budgeted_forced_landing`) before the Taylor-LTT
+    ``on_sky`` scan used by the non-dense paths.
+    """
+    state = particle_state.to_system()
+    positions, velocities, steps = budgeted_forced_landing(
+        state, acc_func, times, integrator_state, step_scheduler
+    )
+    ras, decs = _on_sky_scan(
+        positions[relevant_inds][:, 0, :],
+        velocities[relevant_inds][:, 0, :],
+        times[relevant_inds],
+        observer_positions,
+        acc_func,
+        particle_state.time_reference,
+    )
+    return ras, decs, steps
 
 
 def _state_vec_to_xv(

--- a/src/jorbit/system.py
+++ b/src/jorbit/system.py
@@ -23,12 +23,13 @@ from jorbit.ephemeris.ephemeris import Ephemeris
 from jorbit.integrators import (
     create_leapfrog_times,
     ias15_evolve,
-    ias15_evolve_with_dense_output,
     initialize_ias15_integrator_state,
     leapfrog_evolve,
     make_ltt_propagator,
     next_proposed_dt_global,
     next_proposed_dt_PRS23,
+    stitched_interpolate,
+    stitched_per_query_gather,
 )
 from jorbit.particle import _keplerian_integrate, _keplerian_on_sky
 from jorbit.utils.horizons import get_observer_positions
@@ -299,7 +300,10 @@ class System:
     ################
 
     def integrate(
-        self, times: Time, step_scheduler: str = "prs23"
+        self,
+        times: Time,
+        step_scheduler: str = "prs23",
+        return_steps: bool = False,
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
         """Integrate the System to a given time.
 
@@ -316,37 +320,39 @@ class System:
                 which uses the PRS23 controller from Pham+ 2023, or "global", which
                 uses the controller from the original IAS15 paper. Default is "prs23".
                 Ignored for leapfrog integrators and keplerian systems.
+            return_steps (bool):
+                If True, also return the total number of integration steps taken (summed
+                across any stitched interpolation chunks), appended as the final element
+                of the returned tuple. ``None`` for the analytic Keplerian and fixed-step
+                leapfrog paths, which cannot truncate. Defaults to False.
 
         Returns:
             tuple[jnp.ndarray, jnp.ndarray]:
                 The positions of the particle at the given times, in AU, and the
-                The velocities of the particle at the given times, in AU/day.
+                The velocities of the particle at the given times, in AU/day. If
+                return_steps is True, also the total integration step count.
         """
         times = self._times_to_offsets(times)
         if times.shape == ():
             times = jnp.array([times])
 
         if self._is_keplerian:
-            return _keplerian_system_integrate(
+            positions, velocities = _keplerian_system_integrate(
                 self._state.tracer_positions,
                 self._state.tracer_velocities,
                 self._state.relative_time,
                 times,
             )
-
-        if self._integrator_method in ["Y4", "Y6", "Y8"]:
-            # For leapfrog, need to create intermediate times
+            steps = None
+        elif self._integrator_method in ["Y4", "Y6", "Y8"]:
+            # Leapfrog pre-expands its (uncapped) time array, so it never truncates.
             times, inds = create_leapfrog_times(
                 t0=self._state.relative_time,
                 times=times,
                 biggest_allowed_dt=self._integrator_state.dt,
             )
-        else:
-            inds = jnp.arange(times.shape[0])
-
-        scheduler = self._resolve_step_scheduler(step_scheduler)
-        positions, velocities, _final_system_state, _final_integrator_state = (
-            _integrate(
+            scheduler = self._resolve_step_scheduler(step_scheduler)
+            positions, velocities, _fss, _fis = _integrate(
                 times,
                 self._state,
                 self.gravity,
@@ -355,8 +361,21 @@ class System:
                 inds,
                 scheduler,
             )
-        )
+            steps = None
+        else:
+            # IAS15: stitch dense-output chunks so the 15k buffer can't silently
+            # truncate. See jorbit.integrators.budgeted.
+            scheduler = self._resolve_step_scheduler(step_scheduler)
+            positions, velocities, steps = stitched_interpolate(
+                self._state,
+                self.gravity,
+                times,
+                self._integrator_state,
+                scheduler,
+            )
 
+        if return_steps:
+            return positions, velocities, steps
         return positions, velocities
 
     def ephemeris(
@@ -364,6 +383,7 @@ class System:
         times: Time | jnp.ndarray,
         observer: str | jnp.ndarray,
         step_scheduler: str = "prs23",
+        return_steps: bool = False,
     ) -> SkyCoord:
         """Compute an ephemeris for the system.
 
@@ -381,12 +401,18 @@ class System:
                 which uses the PRS23 controller from Pham+ 2023, or "global", which
                 uses the controller from the original IAS15 paper. Default is "prs23".
                 Ignored for leapfrog integrators and keplerian systems.
+            return_steps (bool):
+                If True, return a tuple of the SkyCoord and the total number of
+                integration steps taken (summed across any stitched interpolation
+                chunks). ``None`` for the analytic Keplerian and fixed-step leapfrog
+                paths, which cannot truncate. Defaults to False.
 
         Returns:
             coords (SkyCoord):
                 The ephemeris of each particle in the system at the given times, in ICRS
                 coordinates and as seen from that specific observer. Each particle has
-                its own light travel time correction applied individually.
+                its own light travel time correction applied individually. If
+                return_steps is True, returns ``(coords, steps)``.
         """
         if isinstance(observer, str):
             observer_positions = get_observer_positions(
@@ -407,34 +433,20 @@ class System:
                 times,
                 observer_positions,
             )
-            return SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs")
+            coords = SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs")
+            if return_steps:
+                return coords, None
+            return coords
 
         if self._integrator_method in ["Y4", "Y6", "Y8"]:
-            # For leapfrog, need to create intermediate times
+            # For leapfrog, need to create intermediate times. Leapfrog has no
+            # b-coefficients; fall back to the original constant-acceleration Taylor.
             times, inds = create_leapfrog_times(
                 t0=self._state.relative_time,
                 times=times,
                 biggest_allowed_dt=self._integrator_state.dt,
             )
-        else:
-            inds = jnp.arange(times.shape[0])
-
-        scheduler = self._resolve_step_scheduler(step_scheduler)
-        # IAS15 has dense-output b-coefficients available, so use them in on_sky's
-        # LTT loop instead of a constant-acceleration Taylor expansion. Leapfrog
-        # has no b-coefficients; fall back to the original Taylor.
-        use_dense_ltt = self._integrator_method not in ("Y4", "Y6", "Y8")
-        if use_dense_ltt:
-            ras, decs = _ephem_ias15(
-                times,
-                self._state,
-                self.gravity,
-                self._integrator_state,
-                observer_positions,
-                inds,
-                scheduler,
-            )
-        else:
+            scheduler = self._resolve_step_scheduler(step_scheduler)
             ras, decs = _ephem(
                 times,
                 self._state,
@@ -445,8 +457,26 @@ class System:
                 inds,
                 scheduler,
             )
+            steps = None
+        else:
+            # IAS15: stitch dense-output chunks (truncation-proof) and use the
+            # b-coefficients for each particle's light-travel-time correction.
+            inds = jnp.arange(times.shape[0])
+            scheduler = self._resolve_step_scheduler(step_scheduler)
+            ras, decs, steps = _ephem_ias15_stitched(
+                times,
+                self._state,
+                self.gravity,
+                self._integrator_state,
+                observer_positions,
+                inds,
+                scheduler,
+            )
 
-        return SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs")
+        coords = SkyCoord(ra=ras, dec=decs, unit=u.rad, frame="icrs")
+        if return_steps:
+            return coords, steps
+        return coords
 
 
 @jax.jit
@@ -520,49 +550,26 @@ def _ephem(
 
 
 @jax.jit
-def _ephem_ias15(
-    times: jnp.ndarray,
-    state: SystemState,
-    acc_func: Callable,
-    integrator_state: IAS15IntegratorState,
+def _dense_ltt_radec_multi(
+    b_per_obs_all: jnp.ndarray,
+    a0_per_obs_all: jnp.ndarray,
+    x0_per_obs_all: jnp.ndarray,
+    v0_per_obs_all: jnp.ndarray,
+    dt_per_obs: jnp.ndarray,
+    h_per_obs: jnp.ndarray,
+    obs_times: jnp.ndarray,
     observer_positions: jnp.ndarray,
-    relevant_inds: jnp.ndarray,
-    step_scheduler: Callable,
+    acc_func: Callable,
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
-    """IAS15-only variant of ``_ephem`` that uses dense-output b-coefficients for LTT.
+    """Per-observation, per-particle dense-output light-travel-time ``on_sky``.
 
-    Vmaps the per-observation polynomial-LTT closure over both the observation axis
-    and the particle axis; each particle gets its own light-travel-time correction.
+    Vmaps the dense-output polynomial-LTT closure over both the observation axis and the
+    particle axis; each particle gets its own light-travel-time correction. Inputs are
+    already gathered per observation: ``b_per_obs_all`` is ``(n_obs, 7, P, 3)``;
+    ``a0/x0/v0_per_obs_all`` are ``(n_obs, P, 3)``; ``dt/h_per_obs/obs_times`` are
+    ``(n_obs,)``; ``observer_positions`` is ``(n_obs, 3)``. Returns ``(ras, decs)`` each
+    shaped ``(P, n_obs)``.
     """
-    (
-        _positions,
-        _velocities,
-        _final_system_state,
-        _final_integrator_state,
-        _iter_num,
-        b_buf,
-        a0_buf,
-        x0_buf,
-        v0_buf,
-        dts_buf,
-        _t_step_starts,
-        step_indices,
-        h_values,
-    ) = ias15_evolve_with_dense_output(
-        state, acc_func, times, integrator_state, step_scheduler
-    )
-
-    obs_times = times[relevant_inds]
-    obs_step_indices = step_indices[relevant_inds]
-    obs_h_values = h_values[relevant_inds]
-
-    # Per-obs gather. Shapes: b (n_obs, 7, n_particles, 3), a0/v0/x0 (n_obs, n_particles, 3),
-    # dt (n_obs,).
-    b_per_obs_all = b_buf[obs_step_indices]
-    a0_per_obs_all = a0_buf[obs_step_indices]
-    x0_per_obs_all = x0_buf[obs_step_indices]
-    v0_per_obs_all = v0_buf[obs_step_indices]
-    dt_per_obs = dts_buf[obs_step_indices]
 
     def per_particle_per_obs(
         b_step: jnp.ndarray,
@@ -600,7 +607,7 @@ def _ephem_ias15(
             x0_obs_p,
             v0_obs_p,
             dt_per_obs,
-            obs_h_values,
+            h_per_obs,
             obs_times,
             observer_positions,
         )
@@ -611,6 +618,40 @@ def _ephem_ias15(
         b_per_obs_all, a0_per_obs_all, x0_per_obs_all, v0_per_obs_all
     )
     return ras, decs
+
+
+def _ephem_ias15_stitched(
+    times: jnp.ndarray,
+    state: SystemState,
+    acc_func: Callable,
+    integrator_state: IAS15IntegratorState,
+    observer_positions: jnp.ndarray,
+    relevant_inds: jnp.ndarray,
+    step_scheduler: Callable,
+) -> tuple[jnp.ndarray, jnp.ndarray, int]:
+    """Truncation-proof IAS15 dense-output ephemeris for the whole system.
+
+    Host-side wrapper that stitches as many dense-output chunks as the span requires
+    (see :func:`jorbit.integrators.stitched_per_query_gather`) before the per-obs,
+    per-particle dense-LTT ``on_sky`` evaluation in :func:`_dense_ltt_radec_multi`.
+    """
+    b_q, a0_q, x0_q, v0_q, dt_q, h_q, steps = stitched_per_query_gather(
+        state, acc_func, times, integrator_state, step_scheduler
+    )
+    # Restrict to observation times (drops any intermediate landing times). For IAS15
+    # relevant_inds is the identity, but keep the indexing uniform with other paths.
+    ras, decs = _dense_ltt_radec_multi(
+        b_q[relevant_inds],
+        a0_q[relevant_inds],
+        x0_q[relevant_inds],
+        v0_q[relevant_inds],
+        dt_q[relevant_inds],
+        h_q[relevant_inds],
+        times[relevant_inds],
+        observer_positions,
+        acc_func,
+    )
+    return ras, decs, steps
 
 
 @jax.jit

--- a/tests/test_budgeted_integration.py
+++ b/tests/test_budgeted_integration.py
@@ -1,0 +1,356 @@
+"""Tests for the truncation-proof orchestration in jorbit.integrators.budgeted.
+
+These exercise the host-side machinery that sits on top of the (hard-capped) IAS15
+backends so that the public Particle/System methods never silently truncate:
+
+- stitching successive interpolation chunks (15k dense-output buffer), and
+- inserting dummy landing times for forced landing (10k per-interval cap).
+
+References are kept internal (stitched vs. forced-landing vs. direct backend) so the
+suite runs offline; observers are passed as explicit position arrays for the same
+reason. Horizons-level accuracy is covered by the existing test_particle.py suite.
+"""
+
+import itertools
+from collections.abc import Callable
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
+import astropy.units as u
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from astropy.time import Time
+
+import jorbit.integrators.ias15 as ias15_module
+from jorbit import Particle, System
+from jorbit.data.constants import SPEED_OF_LIGHT
+from jorbit.integrators import (
+    budgeted_forced_landing,
+    ias15_evolve,
+    ias15_evolve_forced_landing,
+    stitched_interpolate,
+)
+from jorbit.integrators.budgeted import (
+    discover_natural_step_times,
+    insert_budget_dummy_times,
+)
+from jorbit.utils.states import CartesianState
+
+X0 = jnp.array([-2.003779703686627, 1.780533558134481, 0.5203350526739642])
+V0 = jnp.array([-0.006668390915419885, -0.006621147093559814, -0.002036640485149475])
+T0 = Time("2025-01-01")
+
+
+@pytest.fixture(scope="module")
+def particle() -> Particle:
+    """A single perturbed-gravity (newtonian planets) particle reused across tests."""
+    return Particle(x=X0, v=V0, time=T0, gravity="newtonian planets")
+
+
+@pytest.fixture(scope="module")
+def two_body_system() -> System:
+    """A two-tracer System reused across tests."""
+    p1 = Particle(x=X0, v=V0, time=T0, gravity="newtonian planets")
+    p2 = Particle(x=X0 + 1e-3, v=V0 - 1e-5, time=T0, gravity="newtonian planets")
+    return System(particles=[p1, p2], gravity="newtonian planets")
+
+
+def _shrink_cap(value: int) -> Callable[[], None]:
+    """Save/patch/restore the IAS15 dense-output buffer cap (and clear jit caches).
+
+    Returns a (restore) callable. Patching the module constant before clearing the jit
+    caches forces the backend to re-trace with the smaller buffer, so a normal-length
+    span is driven to truncate without needing a genuinely enormous integration.
+    """
+    original = ias15_module.IAS15_MAX_DYNAMIC_STEPS
+    ias15_module.IAS15_MAX_DYNAMIC_STEPS = value
+    jax.clear_caches()
+
+    def restore() -> None:
+        ias15_module.IAS15_MAX_DYNAMIC_STEPS = original
+        jax.clear_caches()
+
+    return restore
+
+
+# ---------------------------------------------------------------------------
+# Pure-function: dummy-time insertion
+# ---------------------------------------------------------------------------
+
+
+def test_insert_budget_dummy_times() -> None:
+    """Dummies subdivide an over-budget interval; requested times are recoverable."""
+    # 99 natural step boundaries strictly inside (0, 10].
+    nst = jnp.cumsum(jnp.full(100, 0.1))  # 0.1 .. 10.0
+    aug, inds = insert_budget_dummy_times(nst, jnp.array([10.0]), t0=0.0, budget=30)
+
+    # Requested time is recoverable via relevant_inds.
+    assert float(aug[inds][0]) == pytest.approx(10.0)
+    # The requested time is the last entry.
+    assert int(inds[0]) == aug.shape[0] - 1
+
+    # No (sub-)interval between consecutive augmented landings exceeds the budget.
+    bounds = np.concatenate([[0.0], np.asarray(aug)])
+    nst_np = np.asarray(nst)
+    for a, b in itertools.pairwise(bounds):
+        n = int(np.sum((nst_np > a) & (nst_np < b)))
+        assert n <= 30
+
+    # A within-budget interval needs no dummies.
+    aug2, inds2 = insert_budget_dummy_times(nst, jnp.array([2.0]), t0=0.0, budget=30)
+    assert aug2.shape[0] == 1
+    assert int(inds2[0]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Common case: stitching/budgeting is a no-op (bit-identical to one backend call)
+# ---------------------------------------------------------------------------
+
+
+def test_stitched_interpolate_matches_single_chunk(particle: Particle) -> None:
+    """A short span fits in one chunk; stitched output is bit-identical to the backend."""
+    times = T0 + np.linspace(0, 90, 10) * u.day
+    toff = particle._times_to_offsets(times)
+    state = particle._cartesian_state.to_system()
+
+    xs, vs, steps = stitched_interpolate(
+        state,
+        particle.gravity,
+        toff,
+        particle._integrator_state,
+        particle._step_scheduler,
+    )
+    pos_d, vel_d, _, _, it = ias15_evolve(
+        state,
+        particle.gravity,
+        toff,
+        particle._integrator_state,
+        particle._step_scheduler,
+    )
+    assert float(jnp.max(jnp.abs(xs - pos_d))) == 0.0
+    assert float(jnp.max(jnp.abs(vs - vel_d))) == 0.0
+    assert steps == int(it)
+
+
+def test_integrate_methods_agree(particle: Particle) -> None:
+    """Integrate (forced landing) and integrate_or_interpolate agree on a clean span."""
+    times = T0 + np.linspace(0, 120, 8) * u.day
+    xi, _ = particle.integrate_or_interpolate(times)
+    xf, _ = particle.integrate(times)
+    # Different numerical paths (interpolation vs. forced landing) but same orbit.
+    assert float(jnp.max(jnp.abs(xi - xf))) < 1e-9  # AU
+
+
+def test_system_integrate_matches_single_chunk(two_body_system: System) -> None:
+    """System.integrate is bit-identical to a direct single-chunk backend call."""
+    sys = two_body_system
+    times = T0 + np.linspace(0, 90, 7) * u.day
+    toff = sys._times_to_offsets(times)
+    scheduler = sys._resolve_step_scheduler("prs23")
+
+    pos, _, steps = sys.integrate(times, return_steps=True)
+    pos_d, _, _, _, it = ias15_evolve(
+        sys._state, sys.gravity, toff, sys._integrator_state, scheduler
+    )
+    assert float(jnp.max(jnp.abs(pos - pos_d))) == 0.0
+    assert steps == int(it)
+
+
+# ---------------------------------------------------------------------------
+# Natural-step discovery and forced-landing dummy round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_discover_natural_step_times(particle: Particle) -> None:
+    """Cumulative natural step times are monotonic and span past the target."""
+    times = T0 + np.linspace(0, 120, 6) * u.day
+    toff = particle._times_to_offsets(times)
+    state = particle._cartesian_state.to_system()
+
+    nst = discover_natural_step_times(
+        state,
+        particle.gravity,
+        toff,
+        particle._integrator_state,
+        particle._step_scheduler,
+    )
+    assert jnp.all(jnp.diff(nst) > 0)
+    assert float(nst[0]) > float(state.relative_time)
+    assert float(nst[-1]) >= float(jnp.max(toff))
+
+
+def test_forced_landing_dummy_roundtrip(particle: Particle) -> None:
+    """Inserting (and dropping) dummy landings reproduces the forced-landing answer.
+
+    Uses a tiny budget so dummies are inserted even on a clean span; the positions at
+    the originally requested times should be unchanged but for the negligible
+    perturbation of splitting steps at the dummy landings.
+    """
+    times = T0 + np.linspace(0, 90, 5) * u.day
+    toff = particle._times_to_offsets(times)
+    state = particle._cartesian_state.to_system()
+
+    pos_ref, _, _, _, _ = ias15_evolve_forced_landing(
+        state,
+        particle.gravity,
+        toff,
+        particle._integrator_state,
+        particle._step_scheduler,
+    )
+    nst = discover_natural_step_times(
+        state,
+        particle.gravity,
+        toff,
+        particle._integrator_state,
+        particle._step_scheduler,
+    )
+    aug, inds = insert_budget_dummy_times(
+        nst, toff, float(state.relative_time), budget=2
+    )
+    assert aug.shape[0] > toff.shape[0]  # dummies were actually inserted
+    pos_aug, _, _, _, _ = ias15_evolve_forced_landing(
+        state,
+        particle.gravity,
+        aug,
+        particle._integrator_state,
+        particle._step_scheduler,
+    )
+    assert float(jnp.max(jnp.abs(pos_aug[inds] - pos_ref))) < 1e-7  # AU (~15 m)
+
+
+# ---------------------------------------------------------------------------
+# Pathological span: stitching recovers what a single buffer would truncate
+# ---------------------------------------------------------------------------
+
+
+def test_stitching_recovers_truncated_span(particle: Particle) -> None:
+    """With a shrunk buffer the single-chunk backend truncates; stitching recovers."""
+    restore = _shrink_cap(6)
+    try:
+        times = T0 + np.linspace(0, 365, 9) * u.day
+        toff = particle._times_to_offsets(times)
+        state = particle._cartesian_state.to_system()
+
+        # A single dense-output buffer no longer reaches the end.
+        _, _, fss, _, _ = ias15_evolve(
+            state,
+            particle.gravity,
+            toff,
+            particle._integrator_state,
+            particle._step_scheduler,
+        )
+        assert float(fss.relative_time) < float(jnp.max(toff)) - 1e-6
+
+        # Stitched interpolation reaches the end across multiple chunks, and matches the
+        # forced-landing path (whose 10k per-interval cap is unaffected by the shrink).
+        xs, _, steps = stitched_interpolate(
+            state,
+            particle.gravity,
+            toff,
+            particle._integrator_state,
+            particle._step_scheduler,
+        )
+        xf, _, _ = budgeted_forced_landing(
+            state,
+            particle.gravity,
+            toff,
+            particle._integrator_state,
+            particle._step_scheduler,
+        )
+        assert steps > 6  # more than one chunk's worth
+        assert float(jnp.max(jnp.abs(xs - xf))) < 1e-8  # AU
+    finally:
+        restore()
+
+
+def test_particle_integrate_truncation_proof(particle: Particle) -> None:
+    """Particle.integrate(_or_interpolate) reach the end even when one buffer cannot."""
+    restore = _shrink_cap(6)
+    try:
+        times = T0 + np.linspace(0, 365, 9) * u.day
+        xi, _ = particle.integrate_or_interpolate(times)
+        xf, _ = particle.integrate(times)
+        # The two truncation-proof paths agree on the final position.
+        assert float(jnp.max(jnp.abs(xi[-1] - xf[-1]))) < 1e-8  # AU
+    finally:
+        restore()
+
+
+# ---------------------------------------------------------------------------
+# Step-count exposure (the user-facing transparency feature)
+# ---------------------------------------------------------------------------
+
+
+def test_ephemeris_return_steps(particle: Particle) -> None:
+    """Ephemeris exposes a step count for both interpolation modes."""
+    times = T0 + np.linspace(0, 60, 5) * u.day
+    observer = jnp.zeros((5, 3))  # barycentric observer keeps the test offline
+
+    coords_i, steps_i = particle.ephemeris(
+        times, observer=observer, interpolate=True, return_steps=True
+    )
+    coords_f, steps_f = particle.ephemeris(
+        times, observer=observer, interpolate=False, return_steps=True
+    )
+    assert int(steps_i) > 0
+    assert int(steps_f) > 0
+    # Dense-LTT interpolation and Taylor-LTT forced landing agree to ~uas.
+    sep = coords_i.separation(coords_f).to(u.arcsec).value
+    assert np.all(sep < 1e-3)
+
+
+def test_system_return_steps(two_body_system: System) -> None:
+    """System.integrate/ephemeris expose step counts."""
+    sys = two_body_system
+    times = T0 + np.linspace(0, 60, 5) * u.day
+    observer = jnp.zeros((5, 3))
+
+    _, _, steps = sys.integrate(times, return_steps=True)
+    assert int(steps) > 0
+    _, esteps = sys.ephemeris(times, observer=observer, return_steps=True)
+    assert int(esteps) > 0
+
+
+# ---------------------------------------------------------------------------
+# Detect-and-raise on the autodiff covariance path
+# ---------------------------------------------------------------------------
+
+
+def test_cov_ephemeris_raises_on_truncation() -> None:
+    """ephemeris(uncertainty=True) raises (not truncates) on an over-long span."""
+    c = CartesianState(
+        x=jnp.array([X0]),
+        v=jnp.array([V0]),
+        time_reference=T0.tdb.jd,
+        acceleration_func_kwargs={"c2": SPEED_OF_LIGHT**2},
+        cov=jnp.eye(6) * 1e-12,
+    )
+    p = Particle(state=c, gravity="newtonian planets")
+    restore = _shrink_cap(6)
+    try:
+        times = T0 + np.linspace(0, 365, 9) * u.day
+        observer = jnp.zeros((9, 3))
+        with pytest.raises(RuntimeError, match="truncate"):
+            p.ephemeris(times, observer=observer, uncertainty=True)
+    finally:
+        restore()
+
+
+# ---------------------------------------------------------------------------
+# Non-IAS15 paths are untouched
+# ---------------------------------------------------------------------------
+
+
+def test_keplerian_return_steps_is_none() -> None:
+    """The analytic Keplerian path reports None steps (it cannot truncate)."""
+    p = Particle(x=X0, v=V0, time=T0, gravity="keplerian")
+    times = T0 + np.linspace(0, 30, 4) * u.day
+    observer = jnp.zeros((4, 3))
+
+    _, _, steps = p.integrate(times, return_steps=True)
+    assert steps is None
+    _, esteps = p.ephemeris(times, observer=observer, return_steps=True)
+    assert esteps is None


### PR DESCRIPTION
This adds protections against silent truncation if an integration requires more steps than the max in the buffer arrays and/or the bounded while loops. Things remain bounded in the back end, but now integrations/ephemerides computed via the front end `Particle` and `System` classes will silently chain together multiple calls to the back end integrators.